### PR TITLE
Tsf 1719

### DIFF
--- a/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/regelmodell/MidlertidigInaktivType.java
+++ b/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/regelmodell/MidlertidigInaktivType.java
@@ -1,0 +1,9 @@
+package no.nav.folketrygdloven.beregningsgrunnlag.regelmodell;
+
+public enum MidlertidigInaktivType {
+
+    A("8-47 A"), B("8-47 B");
+
+    MidlertidigInaktivType(String s) {
+    }
+}

--- a/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/regelmodell/AktivitetStatusModellK9.java
+++ b/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/regelmodell/AktivitetStatusModellK9.java
@@ -1,0 +1,25 @@
+package no.nav.folketrygdloven.skjæringstidspunkt.regelmodell;
+
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.MidlertidigInaktivType;
+import no.nav.fpsak.nare.doc.RuleDocumentationGrunnlag;
+
+@RuleDocumentationGrunnlag
+public class AktivitetStatusModellK9 extends AktivitetStatusModell {
+
+	private MidlertidigInaktivType midlertidigInaktivType;
+
+	public AktivitetStatusModellK9() {
+		super();
+	}
+
+	public AktivitetStatusModellK9(MidlertidigInaktivType midlertidigInaktivType,
+	                                    AktivitetStatusModell aktivitetStatusModell) {
+		super(aktivitetStatusModell);
+		this.midlertidigInaktivType = midlertidigInaktivType;
+
+	}
+
+	public MidlertidigInaktivType getMidlertidigInaktivType() {
+		return midlertidigInaktivType;
+	}
+}

--- a/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/FastsettStatusOgAndelPrPeriode.java
+++ b/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/FastsettStatusOgAndelPrPeriode.java
@@ -60,8 +60,9 @@ public class FastsettStatusOgAndelPrPeriode extends LeafSpecification<AktivitetS
 			    opprettAndelerForAktiviteter(regelmodell, aktivePerioderPåStp);
 		    } else if (MidlertidigInaktivType.A.equals(midlertidigInaktivType)) {
 			    leggTilBrukersAndel(regelmodell);
+		    } else {
+			    throw new IllegalStateException("Det må være satt type A eller B for 8-47");
 		    }
-		    throw new IllegalStateException("Det må være satt type A eller B for 8-47");
 	    } else {
 		    opprettStatusForAktiviteter(regelmodell, aktivePerioderVedStp);
 	    }

--- a/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/FastsettStatusOgAndelPrPeriode.java
+++ b/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/FastsettStatusOgAndelPrPeriode.java
@@ -48,23 +48,12 @@ public class FastsettStatusOgAndelPrPeriode extends LeafSpecification<AktivitetS
         List<AktivPeriode> aktivePerioder = regelmodell.getAktivePerioder();
         List<AktivPeriode> aktivePerioderVedStp = hentAktivePerioderForBeregning(regelmodell.getBeregningstidspunkt(), aktivePerioder);
 
-	    MidlertidigInaktivType midlertidigInaktivType = finnMidlertidigInaktivType(regelmodell);
-
 	    if (harKunYtelsePåSkjæringstidspunkt(aktivePerioderVedStp)) {
             regelmodell.leggTilAktivitetStatus(AktivitetStatus.KUN_YTELSE);
 	        leggTilBrukersAndel(regelmodell);
         }
-	    // TODO: Vi tror dette kun gjelder 8-47A som kun gjelder pleiepenger
-//	    else if (aktivePerioderVedStp.isEmpty() && gjelderMidlertidigInaktiv(aktivePerioder, regelmodell.getSkjæringstidspunktForBeregning())) {
-//		    regelmodell.leggTilAktivitetStatus(AktivitetStatus.MIDL_INAKTIV);
-//		    List<AktivPeriode> aktivePerioderPåStp = finnAktivtArbeidSomStarterPåStp(aktivePerioder, regelmodell.getSkjæringstidspunktForBeregning());
-//		    if (!aktivePerioderPåStp.isEmpty()) {
-//			    opprettAndelerForAktiviteter(regelmodell, aktivePerioderPåStp);
-//		    } else {
-//			    leggTilBrukersAndel(regelmodell);
-//		    }
-//	    }
 	    else {
+		    MidlertidigInaktivType midlertidigInaktivType = finnMidlertidigInaktivType(regelmodell);
 	    	if (midlertidigInaktivType != null && midlertidigInaktivType.equals(MidlertidigInaktivType.B)) {
 			    regelmodell.leggTilAktivitetStatus(AktivitetStatus.MIDL_INAKTIV);
 		    }

--- a/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/FastsettStatusOgAndelPrPeriode.java
+++ b/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/FastsettStatusOgAndelPrPeriode.java
@@ -53,17 +53,21 @@ public class FastsettStatusOgAndelPrPeriode extends LeafSpecification<AktivitetS
 	    if (harKunYtelsePåSkjæringstidspunkt(aktivePerioderVedStp)) {
             regelmodell.leggTilAktivitetStatus(AktivitetStatus.KUN_YTELSE);
 	        leggTilBrukersAndel(regelmodell);
-        } else if (aktivePerioderVedStp.isEmpty() && midlertidigInaktivType != null) {
-		    regelmodell.leggTilAktivitetStatus(AktivitetStatus.MIDL_INAKTIV);
-		    List<AktivPeriode> aktivePerioderPåStp = finnAktivtArbeidSomStarterPåStp(aktivePerioder, regelmodell.getSkjæringstidspunktForBeregning());
-		    if (!aktivePerioderPåStp.isEmpty() && MidlertidigInaktivType.B.equals(midlertidigInaktivType)) {
-			    opprettAndelerForAktiviteter(regelmodell, aktivePerioderPåStp);
-		    } else if (MidlertidigInaktivType.A.equals(midlertidigInaktivType)) {
-			    leggTilBrukersAndel(regelmodell);
-		    } else {
-			    throw new IllegalStateException("Det må være satt type A eller B for 8-47");
+        }
+	    // TODO: Vi tror dette kun gjelder 8-47A som kun gjelder pleiepenger
+//	    else if (aktivePerioderVedStp.isEmpty() && gjelderMidlertidigInaktiv(aktivePerioder, regelmodell.getSkjæringstidspunktForBeregning())) {
+//		    regelmodell.leggTilAktivitetStatus(AktivitetStatus.MIDL_INAKTIV);
+//		    List<AktivPeriode> aktivePerioderPåStp = finnAktivtArbeidSomStarterPåStp(aktivePerioder, regelmodell.getSkjæringstidspunktForBeregning());
+//		    if (!aktivePerioderPåStp.isEmpty()) {
+//			    opprettAndelerForAktiviteter(regelmodell, aktivePerioderPåStp);
+//		    } else {
+//			    leggTilBrukersAndel(regelmodell);
+//		    }
+//	    }
+	    else {
+	    	if (midlertidigInaktivType != null && midlertidigInaktivType.equals(MidlertidigInaktivType.B)) {
+			    regelmodell.leggTilAktivitetStatus(AktivitetStatus.MIDL_INAKTIV);
 		    }
-	    } else {
 		    opprettStatusForAktiviteter(regelmodell, aktivePerioderVedStp);
 	    }
     }


### PR DESCRIPTION
Støtte for midlertidig inaktiv 8-47 B. Har fjernet kode for Type A av 8-47 fordi det trenger vi ikke for omsorgspenger. Vi trenger heller ikke tenke på FL eller SN siden de ikke skal benytte 8-47.