### PR TITLE
Nedjustering grunnet §8-47A skal gjøres uavhengig av uttaks- eller inntektsgradering

### DIFF
--- a/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/FinnGrenseverdi.java
+++ b/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/FinnGrenseverdi.java
@@ -38,20 +38,12 @@ public class FinnGrenseverdi extends LeafSpecification<BeregningsgrunnlagPeriode
 		grunnlag.setTotalUtbetalingsgradFraUttak(totalUtbetalingsgradFraUttak);
 		resultater.put("totalUtbetalingsgradFraUttak", totalUtbetalingsgradFraUttak);
 
-		//hvis §8-47a, skaler med fast faktor
-		var erInaktivTypeA = MidlertidigInaktivType.A.equals(grunnlag.getBeregningsgrunnlag().getMidlertidigInaktivType());
-		if (erInaktivTypeA) {
-			BigDecimal reduksjonsfaktor = grunnlag.getBeregningsgrunnlag().getMidlertidigInaktivTypeAReduksjonsfaktor();
-			grenseverdi = grenseverdi.multiply(reduksjonsfaktor);
-			resultater.put("grad847a", reduksjonsfaktor);
-			grunnlag.setReduksjonsfaktorInaktivTypeA(reduksjonsfaktor);
-		}
-
 		//juster ned med tilkommet inntekt hvis det gir lavere utbetaling enn overstående
+		BigDecimal totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt = null;
 		if (grunnlag.getBeregningsgrunnlag().getToggles().isEnabled("GRADERING_MOT_INNTEKT", false) && !grunnlag.getTilkommetInntektsforholdListe().isEmpty()) {
 			BigDecimal graderingPåToppenAvUttakgraderingPgaTilkommetInntekt = andelBeholdtEtterGradertMotTilkommetInntekt(grunnlag);
 			resultater.put("graderingPåToppenAvUttakgraderingPgaTilkommetInntekt", min(BigDecimal.ONE, graderingPåToppenAvUttakgraderingPgaTilkommetInntekt));
-			BigDecimal totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt = min(BigDecimal.ONE, totalUtbetalingsgradFraUttak.multiply(graderingPåToppenAvUttakgraderingPgaTilkommetInntekt));
+			totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt = min(BigDecimal.ONE, totalUtbetalingsgradFraUttak.multiply(graderingPåToppenAvUttakgraderingPgaTilkommetInntekt));
 			resultater.put("totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt", totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt);
 			grunnlag.setTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt(totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt);
 
@@ -61,6 +53,26 @@ public class FinnGrenseverdi extends LeafSpecification<BeregningsgrunnlagPeriode
 				resultater.put("inntektgraderingsprosent", grunnlag.getInntektsgraderingFraBruttoBeregningsgrunnlag());
 			}
 		}
+		
+		//hvis §8-47a, skaler med fast faktor
+		var erInaktivTypeA = MidlertidigInaktivType.A.equals(grunnlag.getBeregningsgrunnlag().getMidlertidigInaktivType());
+		if (erInaktivTypeA) {
+			BigDecimal reduksjonsfaktor = grunnlag.getBeregningsgrunnlag().getMidlertidigInaktivTypeAReduksjonsfaktor();
+			grenseverdi = grenseverdi.multiply(reduksjonsfaktor);
+			resultater.put("grad847a", reduksjonsfaktor);
+			grunnlag.setReduksjonsfaktorInaktivTypeA(reduksjonsfaktor);
+			
+			BigDecimal justertTotalUtbetalingsgradFraUttak = totalUtbetalingsgradFraUttak.multiply(reduksjonsfaktor);
+			grunnlag.setTotalUtbetalingsgradFraUttak(justertTotalUtbetalingsgradFraUttak);
+			resultater.put("totalUtbetalingsgradFraUttak", justertTotalUtbetalingsgradFraUttak);
+			
+			if (totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt != null) {
+				BigDecimal justertTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt = totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt.multiply(reduksjonsfaktor);
+				grunnlag.setTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt(justertTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt);
+				resultater.put("totalUtbetalingsgradEtterReduksjonVedTilkommetInntekt", justertTotalUtbetalingsgradEtterReduksjonVedTilkommetInntekt);
+			}
+		}
+		
 		resultater.put("grenseverdi", grenseverdi);
 		grunnlag.setGrenseverdi(grenseverdi);
 		SingleEvaluation resultat = ja();


### PR DESCRIPTION
I tillegg skal saksbehandler få se det nedjusterte tallet i tilkommet-inntektskjermbildet og stønadstatistikk få den riktige prosentsatsen oversendt. Derfor lagres 8-47A-justerte prosenter.