### PR TITLE
Revert "Bump no.nav.fpsak.nare:fpsak-nare-core from 2.5.4 to 2.6.1 (#…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
             <dependency>
                 <groupId>no.nav.fpsak.nare</groupId>
                 <artifactId>fpsak-nare-core</artifactId>
-                <version>2.6.1</version>
+                <version>2.5.4</version>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
…448)"

This reverts commit 79b8bd32a94d97a6a865c1111e4f2d99ba486946.