### PR TITLE
Sonar: Returnerer direkte, regel S1488

### DIFF
--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregnBruttoPrArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregnBruttoPrArbeidsforhold.java
@@ -89,9 +89,6 @@ public class RegelBeregnBruttoPrArbeidsforhold implements RuleService<Beregnings
 
         // FP_BR 14.1 Er bruker arbeidstaker?
 
-        var fastsettBruttoBeregningsgrunnlag =
-            rs.beregningHvisRegel(new SjekkOmBrukerErArbeidstaker(arbeidsforhold), manueltFastsattInntekt, sjekkOmNyoppstartetFrilanser);  // NOSONAR: java:S1488
-
-        return fastsettBruttoBeregningsgrunnlag;
+        return rs.beregningHvisRegel(new SjekkOmBrukerErArbeidstaker(arbeidsforhold), manueltFastsattInntekt, sjekkOmNyoppstartetFrilanser);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregnBruttoPrArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregnBruttoPrArbeidsforhold.java
@@ -90,7 +90,7 @@ public class RegelBeregnBruttoPrArbeidsforhold implements RuleService<Beregnings
         // FP_BR 14.1 Er bruker arbeidstaker?
 
         var fastsettBruttoBeregningsgrunnlag =
-            rs.beregningHvisRegel(new SjekkOmBrukerErArbeidstaker(arbeidsforhold), manueltFastsattInntekt, sjekkOmNyoppstartetFrilanser);
+            rs.beregningHvisRegel(new SjekkOmBrukerErArbeidstaker(arbeidsforhold), manueltFastsattInntekt, sjekkOmNyoppstartetFrilanser);  // NOSONAR: java:S1488
 
         return fastsettBruttoBeregningsgrunnlag;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregnBruttoPrArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregnBruttoPrArbeidsforhold.java
@@ -88,7 +88,6 @@ public class RegelBeregnBruttoPrArbeidsforhold implements RuleService<Beregnings
                 new BeregnGrunnlagNyoppstartetFrilanser(arbeidsforhold), beregnPrArbeidsforholdFraAOrdningen);
 
         // FP_BR 14.1 Er bruker arbeidstaker?
-
         return rs.beregningHvisRegel(new SjekkOmBrukerErArbeidstaker(arbeidsforhold), manueltFastsattInntekt, sjekkOmNyoppstartetFrilanser);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregningsgrunnlagATFL.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregningsgrunnlagATFL.java
@@ -85,7 +85,6 @@ public class RegelBeregningsgrunnlagATFL implements RuleService<Beregningsgrunnl
                 rs.beregningsRegel("FP_BR 14.X", "Fastsett beregningsgrunnlag pr arbeidsforhold", speclist, fastsettBeregnetPrÅr);
 
         // FP_BR X.X Ingen regelberegning hvis besteberegning gjelder
-
         return rs.beregningHvisRegel(new SjekkOmBesteberegning(), new Beregnet(), beregningsgrunnlagATFL);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregningsgrunnlagATFL.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregningsgrunnlagATFL.java
@@ -86,9 +86,6 @@ public class RegelBeregningsgrunnlagATFL implements RuleService<Beregningsgrunnl
 
         // FP_BR X.X Ingen regelberegning hvis besteberegning gjelder
 
-        var sjekkOmBesteberegning =
-                rs.beregningHvisRegel(new SjekkOmBesteberegning(), new Beregnet(), beregningsgrunnlagATFL);  // NOSONAR: java:S1488
-
-        return sjekkOmBesteberegning;
+        return rs.beregningHvisRegel(new SjekkOmBesteberegning(), new Beregnet(), beregningsgrunnlagATFL);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregningsgrunnlagATFL.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelBeregningsgrunnlagATFL.java
@@ -87,7 +87,7 @@ public class RegelBeregningsgrunnlagATFL implements RuleService<Beregningsgrunnl
         // FP_BR X.X Ingen regelberegning hvis besteberegning gjelder
 
         var sjekkOmBesteberegning =
-                rs.beregningHvisRegel(new SjekkOmBesteberegning(), new Beregnet(), beregningsgrunnlagATFL);
+                rs.beregningHvisRegel(new SjekkOmBesteberegning(), new Beregnet(), beregningsgrunnlagATFL);  // NOSONAR: java:S1488
 
         return sjekkOmBesteberegning;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelFastsettUtenAvkortingATFL.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelFastsettUtenAvkortingATFL.java
@@ -34,8 +34,7 @@ public class RegelFastsettUtenAvkortingATFL implements RuleService<Beregningsgru
         // FP_BR_29.5.2 Fastsett Avkortet pr år pr beregningsgrunnlagsandel OG Fastsett Avkortet per år
         Specification<BeregningsgrunnlagPeriode> fastsettAvkortet = new FastsettAvkortetLikBruttoBG();
 
-        var fastsettUtenAvkorting =
-                rs.beregningsRegel(ID, BESKRIVELSE, fastsettBrukersAndel, fastsettAvkortet);
+        var fastsettUtenAvkorting = rs.beregningsRegel(ID, BESKRIVELSE, fastsettBrukersAndel, fastsettAvkortet); // NOSONAR: java:S1488
 
         return fastsettUtenAvkorting;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelFastsettUtenAvkortingATFL.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/arbeidstaker/RegelFastsettUtenAvkortingATFL.java
@@ -34,8 +34,6 @@ public class RegelFastsettUtenAvkortingATFL implements RuleService<Beregningsgru
         // FP_BR_29.5.2 Fastsett Avkortet pr år pr beregningsgrunnlagsandel OG Fastsett Avkortet per år
         Specification<BeregningsgrunnlagPeriode> fastsettAvkortet = new FastsettAvkortetLikBruttoBG();
 
-        var fastsettUtenAvkorting = rs.beregningsRegel(ID, BESKRIVELSE, fastsettBrukersAndel, fastsettAvkortet); // NOSONAR: java:S1488
-
-        return fastsettUtenAvkorting;
+        return rs.beregningsRegel(ID, BESKRIVELSE, fastsettBrukersAndel, fastsettAvkortet);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/avkorting/RegelFastsettAvkortetBGOver6GNårRefusjonUnder6G.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/avkorting/RegelFastsettAvkortetBGOver6GNårRefusjonUnder6G.java
@@ -56,10 +56,7 @@ public class RegelFastsettAvkortetBGOver6GNårRefusjonUnder6G implements RuleSer
             avkortAndelerSomIkkegjelderAFtil0, avkortAndelerAndelsmessigOgFastsettBrukersAndel);
 
         //FP_BR_29.8.1 For alle beregningsgrunnlagsandeler som gjelder arbeidsforhold, fastsett avkortet refusjon pr andel
-        var fastsettAvkortetBGOver6GNårRefusjonUnder6G = // NOSONAR: java:S1488
-            rs.beregningsRegel(ID, BESKRIVELSE, new FastsettAvkortetRefusjonPrAndel(), erTotaltBGFraArbeidforholdStørreEnn6G);
-
-        return fastsettAvkortetBGOver6GNårRefusjonUnder6G;
+        return rs.beregningsRegel(ID, BESKRIVELSE, new FastsettAvkortetRefusjonPrAndel(), erTotaltBGFraArbeidforholdStørreEnn6G);
     }
 
     private Specification<BeregningsgrunnlagPeriode> opprettRegelFastsettUtbetalingsbeløpTilBruker() {

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/avkorting/RegelFastsettAvkortetBGOver6GNårRefusjonUnder6G.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/avkorting/RegelFastsettAvkortetBGOver6GNårRefusjonUnder6G.java
@@ -56,9 +56,8 @@ public class RegelFastsettAvkortetBGOver6GNårRefusjonUnder6G implements RuleSer
             avkortAndelerSomIkkegjelderAFtil0, avkortAndelerAndelsmessigOgFastsettBrukersAndel);
 
         //FP_BR_29.8.1 For alle beregningsgrunnlagsandeler som gjelder arbeidsforhold, fastsett avkortet refusjon pr andel
-        var fastsettAvkortetBGOver6GNårRefusjonUnder6G =
+        var fastsettAvkortetBGOver6GNårRefusjonUnder6G = // NOSONAR: java:S1488
             rs.beregningsRegel(ID, BESKRIVELSE, new FastsettAvkortetRefusjonPrAndel(), erTotaltBGFraArbeidforholdStørreEnn6G);
-
 
         return fastsettAvkortetBGOver6GNårRefusjonUnder6G;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/avkorting/RegelFastsettUtbetalingsbeløpTilBruker.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/avkorting/RegelFastsettUtbetalingsbeløpTilBruker.java
@@ -38,7 +38,7 @@ public class RegelFastsettUtbetalingsbeløpTilBruker implements RuleService<Bere
         List<Specification<BeregningsgrunnlagPeriode>> liste = Arrays.asList(new FastsettAndelTilFordeling(),
                 new BeregnProsentvisAndel(),
                 new FastsettBrukersAndelFraArbeidsforholdSomIkkeErFordelt());
-        var fastsattUtbetalingsbeløpTilBruker = rs.beregningsRegel(ID, BESKRIVELSE, liste, vurderOmAndelerErFerdigFordelt);
+        var fastsattUtbetalingsbeløpTilBruker = rs.beregningsRegel(ID, BESKRIVELSE, liste, vurderOmAndelerErFerdigFordelt);  // NOSONAR: java:S1488
 
         return fastsattUtbetalingsbeløpTilBruker;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/avkorting/RegelFastsettUtbetalingsbeløpTilBruker.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/avkorting/RegelFastsettUtbetalingsbeløpTilBruker.java
@@ -38,8 +38,6 @@ public class RegelFastsettUtbetalingsbeløpTilBruker implements RuleService<Bere
         List<Specification<BeregningsgrunnlagPeriode>> liste = Arrays.asList(new FastsettAndelTilFordeling(),
                 new BeregnProsentvisAndel(),
                 new FastsettBrukersAndelFraArbeidsforholdSomIkkeErFordelt());
-        var fastsattUtbetalingsbeløpTilBruker = rs.beregningsRegel(ID, BESKRIVELSE, liste, vurderOmAndelerErFerdigFordelt);  // NOSONAR: java:S1488
-
-        return fastsattUtbetalingsbeløpTilBruker;
+        return rs.beregningsRegel(ID, BESKRIVELSE, liste, vurderOmAndelerErFerdigFordelt);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/RegelFullføreBeregningsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/RegelFullføreBeregningsgrunnlag.java
@@ -63,9 +63,7 @@ public class RegelFullføreBeregningsgrunnlag implements EksportRegel<Beregnings
         var beregnEventuellAvkorting = rs.beregningHvisRegel(new SjekkGradertBeregningsgrunnlagStørreEnnGrenseverdi(), sjekkMaksimaltRefusjonskrav, fastsettUtenAvkorting);
 
 		// FP_BR_29.3 3. For hver beregningsgrunnlagsandel: Fastsett Refusjonskrav for beregnings-grunnlagsandel
-        var fastsettMaksimalRefusjon = rs.beregningsRegel(FastsettMaksimalRefusjon.ID, FastsettMaksimalRefusjon.BESKRIVELSE, // NOSONAR: java:S1488
+        return rs.beregningsRegel(FastsettMaksimalRefusjon.ID, FastsettMaksimalRefusjon.BESKRIVELSE,
             new FastsettMaksimalRefusjon(), beregnEventuellAvkorting);
-
-		return fastsettMaksimalRefusjon;
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/RegelFullføreBeregningsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/RegelFullføreBeregningsgrunnlag.java
@@ -63,8 +63,8 @@ public class RegelFullføreBeregningsgrunnlag implements EksportRegel<Beregnings
         var beregnEventuellAvkorting = rs.beregningHvisRegel(new SjekkGradertBeregningsgrunnlagStørreEnnGrenseverdi(), sjekkMaksimaltRefusjonskrav, fastsettUtenAvkorting);
 
 		// FP_BR_29.3 3. For hver beregningsgrunnlagsandel: Fastsett Refusjonskrav for beregnings-grunnlagsandel
-        var fastsettMaksimalRefusjon = rs.beregningsRegel(FastsettMaksimalRefusjon.ID, FastsettMaksimalRefusjon.BESKRIVELSE,
-				new FastsettMaksimalRefusjon(), beregnEventuellAvkorting);
+        var fastsettMaksimalRefusjon = rs.beregningsRegel(FastsettMaksimalRefusjon.ID, FastsettMaksimalRefusjon.BESKRIVELSE, // NOSONAR: java:S1488
+            new FastsettMaksimalRefusjon(), beregnEventuellAvkorting);
 
 		return fastsettMaksimalRefusjon;
 	}

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/RegelFullføreBeregningsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/RegelFullføreBeregningsgrunnlag.java
@@ -63,7 +63,7 @@ public class RegelFullføreBeregningsgrunnlag implements EksportRegel<Beregnings
         var beregnEventuellAvkorting = rs.beregningHvisRegel(new SjekkGradertBeregningsgrunnlagStørreEnnGrenseverdi(), sjekkMaksimaltRefusjonskrav, fastsettUtenAvkorting);
 
 		// FP_BR_29.3 3. For hver beregningsgrunnlagsandel: Fastsett Refusjonskrav for beregnings-grunnlagsandel
-        return rs.beregningsRegel(FastsettMaksimalRefusjon.ID, FastsettMaksimalRefusjon.BESKRIVELSE,
-            new FastsettMaksimalRefusjon(), beregnEventuellAvkorting);
+        return rs.beregningsRegel(FastsettMaksimalRefusjon.ID, FastsettMaksimalRefusjon.BESKRIVELSE, new FastsettMaksimalRefusjon(),
+            beregnEventuellAvkorting);
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/refusjon/over6g/RegelBeregnRefusjonPrArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/refusjon/over6g/RegelBeregnRefusjonPrArbeidsforhold.java
@@ -31,7 +31,7 @@ public class RegelBeregnRefusjonPrArbeidsforhold implements RuleService<Beregnin
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
         return rs.beregningsRegel(ID, BESKRIVELSE,
-                Arrays.asList(new BeregnArbeidsgiversAndeler(), new BeregnAvkortetRefusjon()),
-                new VurderOmAlleFerdig());
+            Arrays.asList(new BeregnArbeidsgiversAndeler(), new BeregnAvkortetRefusjon()),
+            new VurderOmAlleFerdig());
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/refusjon/over6g/RegelBeregnRefusjonPrArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/refusjon/over6g/RegelBeregnRefusjonPrArbeidsforhold.java
@@ -30,8 +30,7 @@ public class RegelBeregnRefusjonPrArbeidsforhold implements RuleService<Beregnin
     public Specification<BeregningsgrunnlagPeriode> getSpecification() {
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
-        return rs.beregningsRegel(ID, BESKRIVELSE,
-            Arrays.asList(new BeregnArbeidsgiversAndeler(), new BeregnAvkortetRefusjon()),
+        return rs.beregningsRegel(ID, BESKRIVELSE, Arrays.asList(new BeregnArbeidsgiversAndeler(), new BeregnAvkortetRefusjon()),
             new VurderOmAlleFerdig());
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/refusjon/over6g/RegelBeregnRefusjonPrArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/refusjon/over6g/RegelBeregnRefusjonPrArbeidsforhold.java
@@ -30,10 +30,8 @@ public class RegelBeregnRefusjonPrArbeidsforhold implements RuleService<Beregnin
     public Specification<BeregningsgrunnlagPeriode> getSpecification() {
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
-        var beregnRefusjonPrArbeidsforhold = rs.beregningsRegel(ID, BESKRIVELSE,
-                Arrays.asList(new BeregnArbeidsgiversAndeler(), new BeregnAvkortetRefusjon()),  // NOSONAR: java:S1488
+        return rs.beregningsRegel(ID, BESKRIVELSE,
+                Arrays.asList(new BeregnArbeidsgiversAndeler(), new BeregnAvkortetRefusjon()),
                 new VurderOmAlleFerdig());
-
-        return beregnRefusjonPrArbeidsforhold;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/refusjon/over6g/RegelBeregnRefusjonPrArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fastsette/refusjon/over6g/RegelBeregnRefusjonPrArbeidsforhold.java
@@ -31,7 +31,7 @@ public class RegelBeregnRefusjonPrArbeidsforhold implements RuleService<Beregnin
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
         var beregnRefusjonPrArbeidsforhold = rs.beregningsRegel(ID, BESKRIVELSE,
-                Arrays.asList(new BeregnArbeidsgiversAndeler(), new BeregnAvkortetRefusjon()),
+                Arrays.asList(new BeregnArbeidsgiversAndeler(), new BeregnAvkortetRefusjon()),  // NOSONAR: java:S1488
                 new VurderOmAlleFerdig());
 
         return beregnRefusjonPrArbeidsforhold;

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/FastsettNyFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/FastsettNyFordeling.java
@@ -34,8 +34,8 @@ class FastsettNyFordeling implements RuleService<FordelModell> {
 			    .map(fam -> new OmfordelBeregningsgrunnlagTilArbeidsforhold(fam).getSpecification()
 					    .medEvaluationProperty(new ServiceArgument("arbeidsforhold", fam.getArbeidsforhold().map(Arbeidsforhold::toString).orElse("ukjent")))) // TODO (PE) hva er nyttig her?
 			    .toList();
-        return refOverstigerBgAktivitetListe.isEmpty() ? new SettAndelerUtenSøktYtelseTilNull() :
-				        rs.beregningsRegel(ID, BESKRIVELSE, speclist, new SettAndelerUtenSøktYtelseTilNull());
+        return refOverstigerBgAktivitetListe.isEmpty() ? new SettAndelerUtenSøktYtelseTilNull() : rs.beregningsRegel(ID, BESKRIVELSE, speclist,
+            new SettAndelerUtenSøktYtelseTilNull());
     }
 
     private List<FordelAndelModell> finnListeMedAktiteterSomKreverFlyttingAvBeregningsgrunnlag(FordelPeriodeModell beregningsgrunnlagPeriode) {

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/FastsettNyFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/FastsettNyFordeling.java
@@ -34,9 +34,8 @@ class FastsettNyFordeling implements RuleService<FordelModell> {
 			    .map(fam -> new OmfordelBeregningsgrunnlagTilArbeidsforhold(fam).getSpecification()
 					    .medEvaluationProperty(new ServiceArgument("arbeidsforhold", fam.getArbeidsforhold().map(Arbeidsforhold::toString).orElse("ukjent")))) // TODO (PE) hva er nyttig her?
 			    .toList();
-        var beregningsgrunnlagATFL = refOverstigerBgAktivitetListe.isEmpty() ? new SettAndelerUtenSøktYtelseTilNull() :  // NOSONAR: java:S1488
+        return refOverstigerBgAktivitetListe.isEmpty() ? new SettAndelerUtenSøktYtelseTilNull() :
 				        rs.beregningsRegel(ID, BESKRIVELSE, speclist, new SettAndelerUtenSøktYtelseTilNull());
-        return beregningsgrunnlagATFL;
     }
 
     private List<FordelAndelModell> finnListeMedAktiteterSomKreverFlyttingAvBeregningsgrunnlag(FordelPeriodeModell beregningsgrunnlagPeriode) {

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/FastsettNyFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/FastsettNyFordeling.java
@@ -34,7 +34,7 @@ class FastsettNyFordeling implements RuleService<FordelModell> {
 			    .map(fam -> new OmfordelBeregningsgrunnlagTilArbeidsforhold(fam).getSpecification()
 					    .medEvaluationProperty(new ServiceArgument("arbeidsforhold", fam.getArbeidsforhold().map(Arbeidsforhold::toString).orElse("ukjent")))) // TODO (PE) hva er nyttig her?
 			    .toList();
-        var beregningsgrunnlagATFL = refOverstigerBgAktivitetListe.isEmpty() ? new SettAndelerUtenSøktYtelseTilNull() :
+        var beregningsgrunnlagATFL = refOverstigerBgAktivitetListe.isEmpty() ? new SettAndelerUtenSøktYtelseTilNull() :  // NOSONAR: java:S1488
 				        rs.beregningsRegel(ID, BESKRIVELSE, speclist, new SettAndelerUtenSøktYtelseTilNull());
         return beregningsgrunnlagATFL;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/OmfordelBeregningsgrunnlagTilArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/OmfordelBeregningsgrunnlagTilArbeidsforhold.java
@@ -32,5 +32,4 @@ public class OmfordelBeregningsgrunnlagTilArbeidsforhold implements RuleService<
 
         return rs.beregningsRegel(ID, BESKRIVELSE, new OmfordelFraAktiviteterUtenArbeidsforhold(andelMedHøyereRefEnnBG), skalOmfordeleFraFL);
     }
-
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/OmfordelBeregningsgrunnlagTilArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/OmfordelBeregningsgrunnlagTilArbeidsforhold.java
@@ -31,7 +31,7 @@ public class OmfordelBeregningsgrunnlagTilArbeidsforhold implements RuleService<
         var skalOmfordeleFraFL = rs.beregningHvisRegel(new SjekkOmRefusjonOverstigerBeregningsgrunnlag(andelMedHøyereRefEnnBG), omfordelFraFL, new Fordelt());
 
         var omfordelBeregningsgrunnlag = rs.beregningsRegel(ID, BESKRIVELSE, new OmfordelFraAktiviteterUtenArbeidsforhold(andelMedHøyereRefEnnBG), skalOmfordeleFraFL);
-
+  // NOSONAR: java:S1488
         return omfordelBeregningsgrunnlag;
     }
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/OmfordelBeregningsgrunnlagTilArbeidsforhold.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/OmfordelBeregningsgrunnlagTilArbeidsforhold.java
@@ -30,9 +30,7 @@ public class OmfordelBeregningsgrunnlagTilArbeidsforhold implements RuleService<
 
         var skalOmfordeleFraFL = rs.beregningHvisRegel(new SjekkOmRefusjonOverstigerBeregningsgrunnlag(andelMedHøyereRefEnnBG), omfordelFraFL, new Fordelt());
 
-        var omfordelBeregningsgrunnlag = rs.beregningsRegel(ID, BESKRIVELSE, new OmfordelFraAktiviteterUtenArbeidsforhold(andelMedHøyereRefEnnBG), skalOmfordeleFraFL);
-  // NOSONAR: java:S1488
-        return omfordelBeregningsgrunnlag;
+        return rs.beregningsRegel(ID, BESKRIVELSE, new OmfordelFraAktiviteterUtenArbeidsforhold(andelMedHøyereRefEnnBG), skalOmfordeleFraFL);
     }
 
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlag.java
@@ -76,7 +76,8 @@ public class RegelFordelBeregningsgrunnlag implements EksportRegel<FordelPeriode
 
         var sjekkOmBruttoKanDekkeAllRefusjon = rs.beregningHvisRegel(new FinnesMerRefusjonEnnBruttoTilgjengeligOgFlereAndelerKreverRefusjon(), fordelBruttoAndelsmessig, sjekkRefusjonMotBeregningsgrunnlag);
 
-        var sjekkOmDetFinnesTilkommetRefkrav = rs.beregningHvisRegel(new FinnesTilkommetArbeidsandelMedRefusjonskrav(), sjekkOmBruttoKanDekkeAllRefusjon, sjekkRefusjonMotBeregningsgrunnlag);
+        var sjekkOmDetFinnesTilkommetRefkrav = rs.beregningHvisRegel(new FinnesTilkommetArbeidsandelMedRefusjonskrav(), // NOSONAR: java:S1488
+            sjekkOmBruttoKanDekkeAllRefusjon, sjekkRefusjonMotBeregningsgrunnlag);
 
 		return sjekkOmDetFinnesTilkommetRefkrav;
 	}

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlag.java
@@ -76,7 +76,7 @@ public class RegelFordelBeregningsgrunnlag implements EksportRegel<FordelPeriode
 
         var sjekkOmBruttoKanDekkeAllRefusjon = rs.beregningHvisRegel(new FinnesMerRefusjonEnnBruttoTilgjengeligOgFlereAndelerKreverRefusjon(), fordelBruttoAndelsmessig, sjekkRefusjonMotBeregningsgrunnlag);
 
-        return rs.beregningHvisRegel(new FinnesTilkommetArbeidsandelMedRefusjonskrav(),
-            sjekkOmBruttoKanDekkeAllRefusjon, sjekkRefusjonMotBeregningsgrunnlag);
+        return rs.beregningHvisRegel(new FinnesTilkommetArbeidsandelMedRefusjonskrav(), sjekkOmBruttoKanDekkeAllRefusjon,
+            sjekkRefusjonMotBeregningsgrunnlag);
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlag.java
@@ -76,9 +76,7 @@ public class RegelFordelBeregningsgrunnlag implements EksportRegel<FordelPeriode
 
         var sjekkOmBruttoKanDekkeAllRefusjon = rs.beregningHvisRegel(new FinnesMerRefusjonEnnBruttoTilgjengeligOgFlereAndelerKreverRefusjon(), fordelBruttoAndelsmessig, sjekkRefusjonMotBeregningsgrunnlag);
 
-        var sjekkOmDetFinnesTilkommetRefkrav = rs.beregningHvisRegel(new FinnesTilkommetArbeidsandelMedRefusjonskrav(), // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(new FinnesTilkommetArbeidsandelMedRefusjonskrav(),
             sjekkOmBruttoKanDekkeAllRefusjon, sjekkRefusjonMotBeregningsgrunnlag);
-
-		return sjekkOmDetFinnesTilkommetRefkrav;
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlagAndelsmessig.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlagAndelsmessig.java
@@ -21,9 +21,7 @@ public class RegelFordelBeregningsgrunnlagAndelsmessig implements RuleService<Fo
 
         var bestemBeløpSomSkalFordeles = rs.beregningsRegel(FinnMålbeløpForFordelingenPrAndel.ID, FinnMålbeløpForFordelingenPrAndel.BESKRIVELSE, new FinnMålbeløpForFordelingenPrAndel(), utførFordeling);
 
-        var fastsettFraksjonPrAndel = rs.beregningsRegel( // NOSONAR: java:S1488
+        return rs.beregningsRegel(
             FinnFraksjonPrAndel.ID, FinnFraksjonPrAndel.BESKRIVELSE, new FinnFraksjonPrAndel(), bestemBeløpSomSkalFordeles);
-
-	    return fastsettFraksjonPrAndel;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlagAndelsmessig.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlagAndelsmessig.java
@@ -21,8 +21,8 @@ public class RegelFordelBeregningsgrunnlagAndelsmessig implements RuleService<Fo
 
         var bestemBeløpSomSkalFordeles = rs.beregningsRegel(FinnMålbeløpForFordelingenPrAndel.ID, FinnMålbeløpForFordelingenPrAndel.BESKRIVELSE, new FinnMålbeløpForFordelingenPrAndel(), utførFordeling);
 
-        var fastsettFraksjonPrAndel = // NOSONAR: java:S1488
-            rs.beregningsRegel(FinnFraksjonPrAndel.ID, FinnFraksjonPrAndel.BESKRIVELSE, new FinnFraksjonPrAndel(), bestemBeløpSomSkalFordeles);
+        var fastsettFraksjonPrAndel = rs.beregningsRegel( // NOSONAR: java:S1488
+            FinnFraksjonPrAndel.ID, FinnFraksjonPrAndel.BESKRIVELSE, new FinnFraksjonPrAndel(), bestemBeløpSomSkalFordeles);
 
 	    return fastsettFraksjonPrAndel;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlagAndelsmessig.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlagAndelsmessig.java
@@ -21,7 +21,8 @@ public class RegelFordelBeregningsgrunnlagAndelsmessig implements RuleService<Fo
 
         var bestemBeløpSomSkalFordeles = rs.beregningsRegel(FinnMålbeløpForFordelingenPrAndel.ID, FinnMålbeløpForFordelingenPrAndel.BESKRIVELSE, new FinnMålbeløpForFordelingenPrAndel(), utførFordeling);
 
-        var fastsettFraksjonPrAndel = rs.beregningsRegel(FinnFraksjonPrAndel.ID, FinnFraksjonPrAndel.BESKRIVELSE, new FinnFraksjonPrAndel(), bestemBeløpSomSkalFordeles);
+        var fastsettFraksjonPrAndel = // NOSONAR: java:S1488
+            rs.beregningsRegel(FinnFraksjonPrAndel.ID, FinnFraksjonPrAndel.BESKRIVELSE, new FinnFraksjonPrAndel(), bestemBeløpSomSkalFordeles);
 
 	    return fastsettFraksjonPrAndel;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlagAndelsmessig.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/fordel/RegelFordelBeregningsgrunnlagAndelsmessig.java
@@ -21,7 +21,6 @@ public class RegelFordelBeregningsgrunnlagAndelsmessig implements RuleService<Fo
 
         var bestemBeløpSomSkalFordeles = rs.beregningsRegel(FinnMålbeløpForFordelingenPrAndel.ID, FinnMålbeløpForFordelingenPrAndel.BESKRIVELSE, new FinnMålbeløpForFordelingenPrAndel(), utførFordeling);
 
-        return rs.beregningsRegel(
-            FinnFraksjonPrAndel.ID, FinnFraksjonPrAndel.BESKRIVELSE, new FinnFraksjonPrAndel(), bestemBeløpSomSkalFordeles);
+        return rs.beregningsRegel(FinnFraksjonPrAndel.ID, FinnFraksjonPrAndel.BESKRIVELSE, new FinnFraksjonPrAndel(), bestemBeløpSomSkalFordeles);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlag.java
@@ -53,8 +53,8 @@ public class RegelForeslåBeregningsgrunnlag implements EksportRegel<Beregningsg
 				.map(AktivitetStatusMedHjemmel::getAktivitetStatus)
 				.map(this::velgSpecification)
 				.toList();
-        var foreslåBeregningsgrunnlag =
-				rs.beregningsRegel("FP_BR pr status", "Fastsett beregningsgrunnlag pr status", speclist, new Beregnet());
+        var foreslåBeregningsgrunnlag = // NOSONAR: java:S1488
+            rs.beregningsRegel("FP_BR pr status", "Fastsett beregningsgrunnlag pr status", speclist, new Beregnet());
 
 		return foreslåBeregningsgrunnlag;
 	}

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlag.java
@@ -53,10 +53,7 @@ public class RegelForeslåBeregningsgrunnlag implements EksportRegel<Beregningsg
 				.map(AktivitetStatusMedHjemmel::getAktivitetStatus)
 				.map(this::velgSpecification)
 				.toList();
-        var foreslåBeregningsgrunnlag = // NOSONAR: java:S1488
-            rs.beregningsRegel("FP_BR pr status", "Fastsett beregningsgrunnlag pr status", speclist, new Beregnet());
-
-		return foreslåBeregningsgrunnlag;
+        return rs.beregningsRegel("FP_BR pr status", "Fastsett beregningsgrunnlag pr status", speclist, new Beregnet());
 	}
 
 	private Specification<BeregningsgrunnlagPeriode> velgSpecification(AktivitetStatus aktivitetStatus) {

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlagTilNull.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlagTilNull.java
@@ -29,7 +29,6 @@ public class RegelForeslåBeregningsgrunnlagTilNull implements RuleService<Bereg
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
         // FP_BR NULL Sett brutto BG til 0
-        return rs.beregningsRegel(
-            "FP_BR NULL", "Beregn brutto beregingsgrunnlag for ukjent status", new FastsettTilNull(status), new Beregnet());
+        return rs.beregningsRegel("FP_BR NULL", "Beregn brutto beregingsgrunnlag for ukjent status", new FastsettTilNull(status), new Beregnet());
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlagTilNull.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlagTilNull.java
@@ -29,9 +29,8 @@ public class RegelForeslåBeregningsgrunnlagTilNull implements RuleService<Bereg
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
         // FP_BR NULL Sett brutto BG til 0
-        var settTilNull = rs.beregningsRegel("FP_BR NULL", "Beregn brutto beregingsgrunnlag for ukjent status",
-            new FastsettTilNull(status), new Beregnet());
-
+        var settTilNull =  // NOSONAR: java:S1488
+            rs.beregningsRegel("FP_BR NULL", "Beregn brutto beregingsgrunnlag for ukjent status", new FastsettTilNull(status), new Beregnet());
 
         return settTilNull;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlagTilNull.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlagTilNull.java
@@ -29,9 +29,7 @@ public class RegelForeslåBeregningsgrunnlagTilNull implements RuleService<Bereg
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
         // FP_BR NULL Sett brutto BG til 0
-        var settTilNull = rs.beregningsRegel( // NOSONAR: java:S1488
+        return rs.beregningsRegel(
             "FP_BR NULL", "Beregn brutto beregingsgrunnlag for ukjent status", new FastsettTilNull(status), new Beregnet());
-
-        return settTilNull;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlagTilNull.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/RegelForeslåBeregningsgrunnlagTilNull.java
@@ -29,8 +29,8 @@ public class RegelForeslåBeregningsgrunnlagTilNull implements RuleService<Bereg
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
         // FP_BR NULL Sett brutto BG til 0
-        var settTilNull =  // NOSONAR: java:S1488
-            rs.beregningsRegel("FP_BR NULL", "Beregn brutto beregingsgrunnlag for ukjent status", new FastsettTilNull(status), new Beregnet());
+        var settTilNull = rs.beregningsRegel( // NOSONAR: java:S1488
+            "FP_BR NULL", "Beregn brutto beregingsgrunnlag for ukjent status", new FastsettTilNull(status), new Beregnet());
 
         return settTilNull;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagATFLFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagATFLFRISINN.java
@@ -38,11 +38,7 @@ public class RegelBeregningsgrunnlagATFLFRISINN implements RuleService<Beregning
 	    var speclist = arbeidsforhold.stream()
 			    .map(a -> new RegelBeregnBruttoPrArbeidsforholdFRISINN(a).getSpecification().medEvaluationProperty(new ServiceArgument("arbeidsforhold", a.getArbeidsforhold())))
 			    .toList();
-        var beregningsgrunnlagATFL =
-			    rs.beregningsRegel("FRISINN 2.X", "Fastsett beregningsgrunnlag pr arbeidsforhold",  // NOSONAR: java:S1488
+        return rs.beregningsRegel("FRISINN 2.X", "Fastsett beregningsgrunnlag pr arbeidsforhold",
 					    speclist, harInntektForATFLBlittManueltFastsatt);
-
-
-        return beregningsgrunnlagATFL;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagATFLFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagATFLFRISINN.java
@@ -39,7 +39,7 @@ public class RegelBeregningsgrunnlagATFLFRISINN implements RuleService<Beregning
 			    .map(a -> new RegelBeregnBruttoPrArbeidsforholdFRISINN(a).getSpecification().medEvaluationProperty(new ServiceArgument("arbeidsforhold", a.getArbeidsforhold())))
 			    .toList();
         var beregningsgrunnlagATFL =
-			    rs.beregningsRegel("FRISINN 2.X", "Fastsett beregningsgrunnlag pr arbeidsforhold",
+			    rs.beregningsRegel("FRISINN 2.X", "Fastsett beregningsgrunnlag pr arbeidsforhold",  // NOSONAR: java:S1488
 					    speclist, harInntektForATFLBlittManueltFastsatt);
 
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagSNFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagSNFRISINN.java
@@ -28,8 +28,7 @@ public class RegelBeregningsgrunnlagSNFRISINN implements RuleService<Beregningsg
             rs.beregningsRegel(BeregnBruttoBeregningsgrunnlagSNFRISINN.ID, "Beregn brutto beregningsgrunnlag selvstendig næringsdrivende",
                 new BeregnBruttoBeregningsgrunnlagSNFRISINN(), new FastsettBeregnetPrÅr(AktivitetStatus.SN));
 
-
         return rs.beregningsRegel(FastsettBeregningsperiodeSNFRISINN.ID, "Foreslå beregningsgrunnlag for selvstendig næringsdrivende",
-                new FastsettBeregningsperiodeSNFRISINN(), beregnBruttoSN);
+            new FastsettBeregningsperiodeSNFRISINN(), beregnBruttoSN);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagSNFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagSNFRISINN.java
@@ -29,10 +29,7 @@ public class RegelBeregningsgrunnlagSNFRISINN implements RuleService<Beregningsg
                 new BeregnBruttoBeregningsgrunnlagSNFRISINN(), new FastsettBeregnetPrÅr(AktivitetStatus.SN));
 
 
-        var foreslåBeregningsgrunnlagForSelvstendigNæringsdrivende =  // NOSONAR: java:S1488
-            rs.beregningsRegel(FastsettBeregningsperiodeSNFRISINN.ID, "Foreslå beregningsgrunnlag for selvstendig næringsdrivende",
+        return rs.beregningsRegel(FastsettBeregningsperiodeSNFRISINN.ID, "Foreslå beregningsgrunnlag for selvstendig næringsdrivende",
                 new FastsettBeregningsperiodeSNFRISINN(), beregnBruttoSN);
-
-        return foreslåBeregningsgrunnlagForSelvstendigNæringsdrivende;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagSNFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelBeregningsgrunnlagSNFRISINN.java
@@ -29,7 +29,7 @@ public class RegelBeregningsgrunnlagSNFRISINN implements RuleService<Beregningsg
                 new BeregnBruttoBeregningsgrunnlagSNFRISINN(), new FastsettBeregnetPrÅr(AktivitetStatus.SN));
 
 
-        var foreslåBeregningsgrunnlagForSelvstendigNæringsdrivende =
+        var foreslåBeregningsgrunnlagForSelvstendigNæringsdrivende =  // NOSONAR: java:S1488
             rs.beregningsRegel(FastsettBeregningsperiodeSNFRISINN.ID, "Foreslå beregningsgrunnlag for selvstendig næringsdrivende",
                 new FastsettBeregningsperiodeSNFRISINN(), beregnBruttoSN);
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelFastsetteBeregningsgrunnlagForKombinasjonATFLSNFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelFastsetteBeregningsgrunnlagForKombinasjonATFLSNFRISINN.java
@@ -28,7 +28,7 @@ public class RegelFastsetteBeregningsgrunnlagForKombinasjonATFLSNFRISINN impleme
             rs.beregningsRegel("FP_BR 2", "Fastsett beregningsperiode.",
                 new FastsettBeregningsperiodeSNFRISINN(), beregnBruttoSN);
 
-        var beregningsgrunnlagKombinasjon =
+        var beregningsgrunnlagKombinasjon = // NOSONAR: java:S1488
             rs.beregningsRegel("FP_BR_14-15-27-28", "Beregn beregningsgrunnlag for arbeidstaker/frilanser)",
                 new RegelBeregningsgrunnlagATFLFRISINN(regelmodell).getSpecification(), fastsettBeregningsperiode);
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelFastsetteBeregningsgrunnlagForKombinasjonATFLSNFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelFastsetteBeregningsgrunnlagForKombinasjonATFLSNFRISINN.java
@@ -28,10 +28,7 @@ public class RegelFastsetteBeregningsgrunnlagForKombinasjonATFLSNFRISINN impleme
             rs.beregningsRegel("FP_BR 2", "Fastsett beregningsperiode.",
                 new FastsettBeregningsperiodeSNFRISINN(), beregnBruttoSN);
 
-        var beregningsgrunnlagKombinasjon = // NOSONAR: java:S1488
-            rs.beregningsRegel("FP_BR_14-15-27-28", "Beregn beregningsgrunnlag for arbeidstaker/frilanser)",
+        return rs.beregningsRegel("FP_BR_14-15-27-28", "Beregn beregningsgrunnlag for arbeidstaker/frilanser)",
                 new RegelBeregningsgrunnlagATFLFRISINN(regelmodell).getSpecification(), fastsettBeregningsperiode);
-
-        return beregningsgrunnlagKombinasjon;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelForeslåBeregningsgrunnlagFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelForeslåBeregningsgrunnlagFRISINN.java
@@ -38,10 +38,7 @@ public class RegelForeslåBeregningsgrunnlagFRISINN implements EksportRegel<Bere
 				.map(AktivitetStatusMedHjemmel::getAktivitetStatus)
 				.map(this::velgSpecification)
 				.toList();
-        var foreslåBeregningsgrunnlag = // NOSONAR: java:S1488
-            rs.beregningsRegel("FRISINN pr status", "Fastsett beregningsgrunnlag pr status", speclist, new Beregnet());
-
-		return foreslåBeregningsgrunnlag;
+        return rs.beregningsRegel("FRISINN pr status", "Fastsett beregningsgrunnlag pr status", speclist, new Beregnet());
     }
 
 	private Specification<BeregningsgrunnlagPeriode> velgSpecification(AktivitetStatus aktivitetStatus) {

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelForeslåBeregningsgrunnlagFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/foreslå/frisinn/RegelForeslåBeregningsgrunnlagFRISINN.java
@@ -38,8 +38,8 @@ public class RegelForeslåBeregningsgrunnlagFRISINN implements EksportRegel<Bere
 				.map(AktivitetStatusMedHjemmel::getAktivitetStatus)
 				.map(this::velgSpecification)
 				.toList();
-        var foreslåBeregningsgrunnlag =
-				rs.beregningsRegel("FRISINN pr status", "Fastsett beregningsgrunnlag pr status", speclist, new Beregnet());
+        var foreslåBeregningsgrunnlag = // NOSONAR: java:S1488
+            rs.beregningsRegel("FRISINN pr status", "Fastsett beregningsgrunnlag pr status", speclist, new Beregnet());
 
 		return foreslåBeregningsgrunnlag;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFastsettAndelBGOver6G.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFastsettAndelBGOver6G.java
@@ -50,9 +50,10 @@ public class RegelFastsettAndelBGOver6G implements RuleService<Beregningsgrunnla
         }
 
         //FP_BR_29.8.2 Er totalt BG for beregningsgrunnlagsandeler fra arbeidsforhold > 6G?
-        var erTotaltBGFraArbeidforholdStørreEnn6G = rs.beregningHvisRegel(new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdi(),
-            avkortAndelerSomIkkegjelderAFtil0, avkortAndelerAndelsmessigOgFastsettBrukersAndel);
-
+        var erTotaltBGFraArbeidforholdStørreEnn6G = rs.beregningHvisRegel( // NOSONAR: java:S1488
+            new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdi(),
+            avkortAndelerSomIkkegjelderAFtil0,
+            avkortAndelerAndelsmessigOgFastsettBrukersAndel);
 
         return erTotaltBGFraArbeidforholdStørreEnn6G;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFastsettAndelBGOver6G.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFastsettAndelBGOver6G.java
@@ -50,10 +50,7 @@ public class RegelFastsettAndelBGOver6G implements RuleService<Beregningsgrunnla
         }
 
         //FP_BR_29.8.2 Er totalt BG for beregningsgrunnlagsandeler fra arbeidsforhold > 6G?
-        return rs.beregningHvisRegel(
-            new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdi(),
-            avkortAndelerSomIkkegjelderAFtil0,
+        return rs.beregningHvisRegel(new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdi(), avkortAndelerSomIkkegjelderAFtil0,
             avkortAndelerAndelsmessigOgFastsettBrukersAndel);
     }
-
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFastsettAndelBGOver6G.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFastsettAndelBGOver6G.java
@@ -50,12 +50,10 @@ public class RegelFastsettAndelBGOver6G implements RuleService<Beregningsgrunnla
         }
 
         //FP_BR_29.8.2 Er totalt BG for beregningsgrunnlagsandeler fra arbeidsforhold > 6G?
-        var erTotaltBGFraArbeidforholdStørreEnn6G = rs.beregningHvisRegel( // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(
             new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdi(),
             avkortAndelerSomIkkegjelderAFtil0,
             avkortAndelerAndelsmessigOgFastsettBrukersAndel);
-
-        return erTotaltBGFraArbeidforholdStørreEnn6G;
     }
 
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdi.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdi.java
@@ -29,7 +29,7 @@ public class RegelFinnGrenseverdi implements EksportRegel<BeregningsgrunnlagPeri
 
 
 		// FP_BR_29.1 Skal finne grenseverdi uten å ta hensyn til fordeling?
-        var skalfinneGrenseverdiUtenFordeling = rs.beregningHvisRegel(
+        var skalfinneGrenseverdiUtenFordeling = rs.beregningHvisRegel(  // NOSONAR: java:S1488
 				new SkalFinneGrenseverdiUtenFordeling(),
 				new RegelFinnGrenseverdiUtenFordeling(regelmodell).getSpecification(),
 				new RegelFinnGrenseverdiMedFordeling(regelmodell).getSpecification());

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdi.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdi.java
@@ -29,11 +29,9 @@ public class RegelFinnGrenseverdi implements EksportRegel<BeregningsgrunnlagPeri
 
 
 		// FP_BR_29.1 Skal finne grenseverdi uten å ta hensyn til fordeling?
-        var skalfinneGrenseverdiUtenFordeling = rs.beregningHvisRegel(  // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(
 				new SkalFinneGrenseverdiUtenFordeling(),
 				new RegelFinnGrenseverdiUtenFordeling(regelmodell).getSpecification(),
 				new RegelFinnGrenseverdiMedFordeling(regelmodell).getSpecification());
-
-		return skalfinneGrenseverdiUtenFordeling;
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdiMedFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdiMedFordeling.java
@@ -47,7 +47,7 @@ public class RegelFinnGrenseverdiMedFordeling implements EksportRegel<Beregnings
             fastsettGrenseverdi);
 
         // FP_BR_29.4 4. Brutto beregnings-grunnlag totalt > 6G?
-        var beregnEventuellAvkorting = rs.beregningHvisRegel(
+        var beregnEventuellAvkorting = rs.beregningHvisRegel(  // NOSONAR: java:S1488
             new SjekkBeregningsgrunnlagStørreEnnGrenseverdi(),
             fastsettAvkortet,
             fastsettUtenAvkorting);

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdiMedFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdiMedFordeling.java
@@ -47,9 +47,6 @@ public class RegelFinnGrenseverdiMedFordeling implements EksportRegel<Beregnings
             fastsettGrenseverdi);
 
         // FP_BR_29.4 4. Brutto beregnings-grunnlag totalt > 6G?
-        return rs.beregningHvisRegel(
-            new SjekkBeregningsgrunnlagStørreEnnGrenseverdi(),
-            fastsettAvkortet,
-            fastsettUtenAvkorting);
+        return rs.beregningHvisRegel(new SjekkBeregningsgrunnlagStørreEnnGrenseverdi(), fastsettAvkortet, fastsettUtenAvkorting);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdiMedFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/RegelFinnGrenseverdiMedFordeling.java
@@ -47,11 +47,9 @@ public class RegelFinnGrenseverdiMedFordeling implements EksportRegel<Beregnings
             fastsettGrenseverdi);
 
         // FP_BR_29.4 4. Brutto beregnings-grunnlag totalt > 6G?
-        var beregnEventuellAvkorting = rs.beregningHvisRegel(  // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(
             new SjekkBeregningsgrunnlagStørreEnnGrenseverdi(),
             fastsettAvkortet,
             fastsettUtenAvkorting);
-
-        return beregnEventuellAvkorting;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFastsettAndelBGOver6GUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFastsettAndelBGOver6GUtenFordeling.java
@@ -50,8 +50,7 @@ class RegelFastsettAndelBGOver6GUtenFordeling implements RuleService<Beregningsg
 		}
 
 		//FP_BR_29.8.2 Er totalt BG for beregningsgrunnlagsandeler fra arbeidsforhold > 6G?
-        return rs.beregningHvisRegel(
-            new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling(), avkortAndelerSomIkkegjelderAFtil0,
+        return rs.beregningHvisRegel(new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling(), avkortAndelerSomIkkegjelderAFtil0,
             avkortAndelerAndelsmessigOgFastsettBrukersAndel);
 	}
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFastsettAndelBGOver6GUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFastsettAndelBGOver6GUtenFordeling.java
@@ -50,12 +50,9 @@ class RegelFastsettAndelBGOver6GUtenFordeling implements RuleService<Beregningsg
 		}
 
 		//FP_BR_29.8.2 Er totalt BG for beregningsgrunnlagsandeler fra arbeidsforhold > 6G?
-        var erTotaltBGFraArbeidforholdStørreEnn6G = rs.beregningHvisRegel( // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(
             new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling(), avkortAndelerSomIkkegjelderAFtil0,
             avkortAndelerAndelsmessigOgFastsettBrukersAndel);
-
-
-		return erTotaltBGFraArbeidforholdStørreEnn6G;
 	}
 
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFastsettAndelBGOver6GUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFastsettAndelBGOver6GUtenFordeling.java
@@ -50,8 +50,9 @@ class RegelFastsettAndelBGOver6GUtenFordeling implements RuleService<Beregningsg
 		}
 
 		//FP_BR_29.8.2 Er totalt BG for beregningsgrunnlagsandeler fra arbeidsforhold > 6G?
-        var erTotaltBGFraArbeidforholdStørreEnn6G = rs.beregningHvisRegel(new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling(),
-				avkortAndelerSomIkkegjelderAFtil0, avkortAndelerAndelsmessigOgFastsettBrukersAndel);
+        var erTotaltBGFraArbeidforholdStørreEnn6G = rs.beregningHvisRegel( // NOSONAR: java:S1488
+            new SjekkOmTotaltBGForArbeidsforholdStørreEnnGrenseverdiUtenFordeling(), avkortAndelerSomIkkegjelderAFtil0,
+            avkortAndelerAndelsmessigOgFastsettBrukersAndel);
 
 
 		return erTotaltBGFraArbeidforholdStørreEnn6G;

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFinnGrenseverdiUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFinnGrenseverdiUtenFordeling.java
@@ -47,7 +47,7 @@ public class RegelFinnGrenseverdiUtenFordeling implements EksportRegel<Beregning
 				fastsettGrenseverdi);
 
 		// FP_BR_29.4 4. Brutto beregnings-grunnlag totalt > 6G?
-        var beregnEventuellAvkorting = rs.beregningHvisRegel(
+        var beregnEventuellAvkorting = rs.beregningHvisRegel(  // NOSONAR: java:S1488
 				new SjekkBeregningsgrunnlagStørreEnnGrenseverdi(),
 				fastsettAvkortet,
 				fastsettUtenAvkorting);

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFinnGrenseverdiUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFinnGrenseverdiUtenFordeling.java
@@ -47,11 +47,9 @@ public class RegelFinnGrenseverdiUtenFordeling implements EksportRegel<Beregning
 				fastsettGrenseverdi);
 
 		// FP_BR_29.4 4. Brutto beregnings-grunnlag totalt > 6G?
-        var beregnEventuellAvkorting = rs.beregningHvisRegel(  // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(
 				new SjekkBeregningsgrunnlagStørreEnnGrenseverdi(),
 				fastsettAvkortet,
 				fastsettUtenAvkorting);
-
-		return beregnEventuellAvkorting;
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFinnGrenseverdiUtenFordeling.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/grenseverdi/utenfordeling/RegelFinnGrenseverdiUtenFordeling.java
@@ -47,9 +47,6 @@ public class RegelFinnGrenseverdiUtenFordeling implements EksportRegel<Beregning
 				fastsettGrenseverdi);
 
 		// FP_BR_29.4 4. Brutto beregnings-grunnlag totalt > 6G?
-        return rs.beregningHvisRegel(
-				new SjekkBeregningsgrunnlagStørreEnnGrenseverdi(),
-				fastsettAvkortet,
-				fastsettUtenAvkorting);
+        return rs.beregningHvisRegel(new SjekkBeregningsgrunnlagStørreEnnGrenseverdi(), fastsettAvkortet, fastsettUtenAvkorting);
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/inaktiv/RegelBeregningsgrunnlagInaktivMedAvviksvurdering.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/inaktiv/RegelBeregningsgrunnlagInaktivMedAvviksvurdering.java
@@ -82,7 +82,7 @@ public class RegelBeregningsgrunnlagInaktivMedAvviksvurdering implements RuleSer
 //      Beregn gjennomsnittlig PGI
 //      Beregn oppjustert inntekt for årene i beregningsperioden
 //      Fastsett beregningsperiode
-        var foreslåBeregningsgrunnlagForBrukersAndel =
+        var foreslåBeregningsgrunnlagForBrukersAndel =  // NOSONAR: java:S1488
 				rs.beregningsRegel("BR_8_47_1", "Foreslå beregningsgrunnlag for brukers andel",
 						Arrays.asList(new FastsettBeregningsperiodeForAktivitetstatus(AktivitetStatus.BA),
 								new SettHjemmelInaktiv(),

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/inaktiv/RegelBeregningsgrunnlagInaktivMedAvviksvurdering.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/inaktiv/RegelBeregningsgrunnlagInaktivMedAvviksvurdering.java
@@ -82,13 +82,10 @@ public class RegelBeregningsgrunnlagInaktivMedAvviksvurdering implements RuleSer
 //      Beregn gjennomsnittlig PGI
 //      Beregn oppjustert inntekt for årene i beregningsperioden
 //      Fastsett beregningsperiode
-        var foreslåBeregningsgrunnlagForBrukersAndel =  // NOSONAR: java:S1488
-				rs.beregningsRegel("BR_8_47_1", "Foreslå beregningsgrunnlag for brukers andel",
+        return rs.beregningsRegel("BR_8_47_1", "Foreslå beregningsgrunnlag for brukers andel",
 						Arrays.asList(new FastsettBeregningsperiodeForAktivitetstatus(AktivitetStatus.BA),
 								new SettHjemmelInaktiv(),
 								new BeregnOppjustertInntektForAktivitetstatus(AktivitetStatus.BA),
 								new BeregnGjennomsnittligPGIForAktivitetstatus(AktivitetStatus.BA)), sjekkOmManueltFastsattInntekt);
-
-		return foreslåBeregningsgrunnlagForBrukersAndel;
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/militær/RegelForeslåBeregningsgrunnlagMilitær.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/militær/RegelForeslåBeregningsgrunnlagMilitær.java
@@ -25,7 +25,7 @@ public class RegelForeslåBeregningsgrunnlagMilitær implements RuleService<Bere
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
         // FP_BR 32.6 Foreslå beregningsgrunnlag for status militær og sivilforsvarstjeneste
-        return rs.beregningsRegel(ForeslåBeregningsgrunnlagMS.ID,
-            ForeslåBeregningsgrunnlagMS.BESKRIVELSE, new ForeslåBeregningsgrunnlagMS(), new Beregnet());
+        return rs.beregningsRegel(ForeslåBeregningsgrunnlagMS.ID, ForeslåBeregningsgrunnlagMS.BESKRIVELSE, new ForeslåBeregningsgrunnlagMS(),
+            new Beregnet());
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/militær/RegelForeslåBeregningsgrunnlagMilitær.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/militær/RegelForeslåBeregningsgrunnlagMilitær.java
@@ -25,8 +25,8 @@ public class RegelForeslåBeregningsgrunnlagMilitær implements RuleService<Bere
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
         // FP_BR 32.6 Foreslå beregningsgrunnlag for status militær og sivilforsvarstjeneste
-        var foreslåBeregningsgrunnlagMS = rs.beregningsRegel(ForeslåBeregningsgrunnlagMS.ID, ForeslåBeregningsgrunnlagMS.BESKRIVELSE,
-            new ForeslåBeregningsgrunnlagMS(), new Beregnet());
+        var foreslåBeregningsgrunnlagMS = rs.beregningsRegel(ForeslåBeregningsgrunnlagMS.ID, // NOSONAR: java:S1488
+            ForeslåBeregningsgrunnlagMS.BESKRIVELSE, new ForeslåBeregningsgrunnlagMS(), new Beregnet());
 
         return foreslåBeregningsgrunnlagMS;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/militær/RegelForeslåBeregningsgrunnlagMilitær.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/militær/RegelForeslåBeregningsgrunnlagMilitær.java
@@ -25,9 +25,7 @@ public class RegelForeslåBeregningsgrunnlagMilitær implements RuleService<Bere
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
 
         // FP_BR 32.6 Foreslå beregningsgrunnlag for status militær og sivilforsvarstjeneste
-        var foreslåBeregningsgrunnlagMS = rs.beregningsRegel(ForeslåBeregningsgrunnlagMS.ID, // NOSONAR: java:S1488
+        return rs.beregningsRegel(ForeslåBeregningsgrunnlagMS.ID,
             ForeslåBeregningsgrunnlagMS.BESKRIVELSE, new ForeslåBeregningsgrunnlagMS(), new Beregnet());
-
-        return foreslåBeregningsgrunnlagMS;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/gradering/FastsettPerioderGraderingRegel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/gradering/FastsettPerioderGraderingRegel.java
@@ -42,7 +42,7 @@ public class FastsettPerioderGraderingRegel implements EksportRegel<PeriodeModel
             new PeriodiserForGradering(),
             new Periodisert());
 
-        var identifiserÅrsaker = rs.beregningsRegel(
+        var identifiserÅrsaker = rs.beregningsRegel(  // NOSONAR: java:S1488
             IdentifiserPeriodeÅrsakerGradering.ID,
 		        IdentifiserPeriodeÅrsakerGradering.BESKRIVELSE,
             new IdentifiserPeriodeÅrsakerGradering(),

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/gradering/FastsettPerioderGraderingRegel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/gradering/FastsettPerioderGraderingRegel.java
@@ -42,13 +42,11 @@ public class FastsettPerioderGraderingRegel implements EksportRegel<PeriodeModel
             new PeriodiserForGradering(),
             new Periodisert());
 
-        var identifiserÅrsaker = rs.beregningsRegel(  // NOSONAR: java:S1488
+        return rs.beregningsRegel(
             IdentifiserPeriodeÅrsakerGradering.ID,
 		        IdentifiserPeriodeÅrsakerGradering.BESKRIVELSE,
             new IdentifiserPeriodeÅrsakerGradering(),
             periodiser);
-
-        return identifiserÅrsaker;
 
     }
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/naturalytelse/FastsettPerioderNaturalytelseRegel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/naturalytelse/FastsettPerioderNaturalytelseRegel.java
@@ -42,7 +42,7 @@ public class FastsettPerioderNaturalytelseRegel implements EksportRegel<PeriodeM
             new PeriodiserForNaturalytelse(),
             new Periodisert());
 
-        var identifiserÅrsaker = rs.beregningsRegel(
+        var identifiserÅrsaker = rs.beregningsRegel(  // NOSONAR: java:S1488
             IdentifiserPeriodeÅrsakerNaturalytelse.ID,
             IdentifiserPeriodeÅrsakerNaturalytelse.BESKRIVELSE,
             new IdentifiserPeriodeÅrsakerNaturalytelse(),

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/naturalytelse/FastsettPerioderNaturalytelseRegel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/naturalytelse/FastsettPerioderNaturalytelseRegel.java
@@ -42,13 +42,11 @@ public class FastsettPerioderNaturalytelseRegel implements EksportRegel<PeriodeM
             new PeriodiserForNaturalytelse(),
             new Periodisert());
 
-        var identifiserÅrsaker = rs.beregningsRegel(  // NOSONAR: java:S1488
+        return rs.beregningsRegel(
             IdentifiserPeriodeÅrsakerNaturalytelse.ID,
             IdentifiserPeriodeÅrsakerNaturalytelse.BESKRIVELSE,
             new IdentifiserPeriodeÅrsakerNaturalytelse(),
             periodiser);
-
-        return identifiserÅrsaker;
 
     }
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/refusjon/FastsettPerioderRefusjonRegel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/refusjon/FastsettPerioderRefusjonRegel.java
@@ -42,13 +42,11 @@ public class FastsettPerioderRefusjonRegel implements EksportRegel<PeriodeModell
 				new PeriodiserForRefusjon(),
 				new Periodisert());
 
-		var identifiserÅrsaker = rs.beregningsRegel(  // NOSONAR: java:S1488
+		return rs.beregningsRegel(
 				IdentifiserPeriodeÅrsakerRefusjon.ID,
 				IdentifiserPeriodeÅrsakerRefusjon.BESKRIVELSE,
 				new IdentifiserPeriodeÅrsakerRefusjon(),
 				periodiser);
-
-		return identifiserÅrsaker;
 
 	}
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/refusjon/FastsettPerioderRefusjonRegel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/refusjon/FastsettPerioderRefusjonRegel.java
@@ -42,7 +42,7 @@ public class FastsettPerioderRefusjonRegel implements EksportRegel<PeriodeModell
 				new PeriodiserForRefusjon(),
 				new Periodisert());
 
-		var identifiserÅrsaker = rs.beregningsRegel(
+		var identifiserÅrsaker = rs.beregningsRegel(  // NOSONAR: java:S1488
 				IdentifiserPeriodeÅrsakerRefusjon.ID,
 				IdentifiserPeriodeÅrsakerRefusjon.BESKRIVELSE,
 				new IdentifiserPeriodeÅrsakerRefusjon(),

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/utbetalingsgrad/FastsettPerioderForUtbetalingsgradRegel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/utbetalingsgrad/FastsettPerioderForUtbetalingsgradRegel.java
@@ -42,13 +42,11 @@ public class FastsettPerioderForUtbetalingsgradRegel implements EksportRegel<Per
             new PeriodiserForUtbetalingsgrad(),
             new Periodisert());
 
-        var identifiserÅrsaker = rs.beregningsRegel(  // NOSONAR: java:S1488
+        return rs.beregningsRegel(
             IdentifiserPeriodeÅrsakForUtbetalingsgrad.ID,
             IdentifiserPeriodeÅrsakForUtbetalingsgrad.BESKRIVELSE,
             new IdentifiserPeriodeÅrsakForUtbetalingsgrad(),
             periodiser);
-
-        return identifiserÅrsaker;
 
     }
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/utbetalingsgrad/FastsettPerioderForUtbetalingsgradRegel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/perioder/utbetalingsgrad/FastsettPerioderForUtbetalingsgradRegel.java
@@ -42,7 +42,7 @@ public class FastsettPerioderForUtbetalingsgradRegel implements EksportRegel<Per
             new PeriodiserForUtbetalingsgrad(),
             new Periodisert());
 
-        var identifiserÅrsaker = rs.beregningsRegel(
+        var identifiserÅrsaker = rs.beregningsRegel(  // NOSONAR: java:S1488
             IdentifiserPeriodeÅrsakForUtbetalingsgrad.ID,
             IdentifiserPeriodeÅrsakForUtbetalingsgrad.BESKRIVELSE,
             new IdentifiserPeriodeÅrsakForUtbetalingsgrad(),

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/selvstendig/RegelBeregningsgrunnlagSN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/selvstendig/RegelBeregningsgrunnlagSN.java
@@ -86,6 +86,6 @@ public class RegelBeregningsgrunnlagSN implements RuleService<Beregningsgrunnlag
 //      FP_BR 2.9 Beregn oppjustert inntekt for årene i beregningsperioden
 //      FP_BR 2.1 Fastsett beregningsperiode
         return rs.beregningsRegel("FP_BR 2", "Foreslå beregningsgrunnlag for selvstendig næringsdrivende",
-                Arrays.asList(new FastsettBeregningsperiodeForAktivitetstatus(AktivitetStatus.SN), new SettHjemmelSN(), new BeregnOppjustertInntektForAktivitetstatus(AktivitetStatus.SN), new BeregnGjennomsnittligPGIForAktivitetstatus(AktivitetStatus.SN)), erBeregningsgrunnlagetBesteberegnet);
+            Arrays.asList(new FastsettBeregningsperiodeForAktivitetstatus(AktivitetStatus.SN), new SettHjemmelSN(), new BeregnOppjustertInntektForAktivitetstatus(AktivitetStatus.SN), new BeregnGjennomsnittligPGIForAktivitetstatus(AktivitetStatus.SN)), erBeregningsgrunnlagetBesteberegnet);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/selvstendig/RegelBeregningsgrunnlagSN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/selvstendig/RegelBeregningsgrunnlagSN.java
@@ -85,7 +85,7 @@ public class RegelBeregningsgrunnlagSN implements RuleService<Beregningsgrunnlag
 //      FP_BR 2.2 Beregn gjennomsnittlig PGI
 //      FP_BR 2.9 Beregn oppjustert inntekt for årene i beregningsperioden
 //      FP_BR 2.1 Fastsett beregningsperiode
-        var foreslåBeregningsgrunnlagForSelvstendigNæringsdrivende =
+        var foreslåBeregningsgrunnlagForSelvstendigNæringsdrivende =  // NOSONAR: java:S1488
             rs.beregningsRegel("FP_BR 2", "Foreslå beregningsgrunnlag for selvstendig næringsdrivende",
                 Arrays.asList(new FastsettBeregningsperiodeForAktivitetstatus(AktivitetStatus.SN), new SettHjemmelSN(), new BeregnOppjustertInntektForAktivitetstatus(AktivitetStatus.SN), new BeregnGjennomsnittligPGIForAktivitetstatus(AktivitetStatus.SN)), erBeregningsgrunnlagetBesteberegnet);
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/selvstendig/RegelBeregningsgrunnlagSN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/selvstendig/RegelBeregningsgrunnlagSN.java
@@ -85,10 +85,7 @@ public class RegelBeregningsgrunnlagSN implements RuleService<Beregningsgrunnlag
 //      FP_BR 2.2 Beregn gjennomsnittlig PGI
 //      FP_BR 2.9 Beregn oppjustert inntekt for årene i beregningsperioden
 //      FP_BR 2.1 Fastsett beregningsperiode
-        var foreslåBeregningsgrunnlagForSelvstendigNæringsdrivende =  // NOSONAR: java:S1488
-            rs.beregningsRegel("FP_BR 2", "Foreslå beregningsgrunnlag for selvstendig næringsdrivende",
+        return rs.beregningsRegel("FP_BR 2", "Foreslå beregningsgrunnlag for selvstendig næringsdrivende",
                 Arrays.asList(new FastsettBeregningsperiodeForAktivitetstatus(AktivitetStatus.SN), new SettHjemmelSN(), new BeregnOppjustertInntektForAktivitetstatus(AktivitetStatus.SN), new BeregnGjennomsnittligPGIForAktivitetstatus(AktivitetStatus.SN)), erBeregningsgrunnlagetBesteberegnet);
-
-        return foreslåBeregningsgrunnlagForSelvstendigNæringsdrivende;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/selvstendig/RegelBeregningsgrunnlagSN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/selvstendig/RegelBeregningsgrunnlagSN.java
@@ -86,6 +86,8 @@ public class RegelBeregningsgrunnlagSN implements RuleService<Beregningsgrunnlag
 //      FP_BR 2.9 Beregn oppjustert inntekt for årene i beregningsperioden
 //      FP_BR 2.1 Fastsett beregningsperiode
         return rs.beregningsRegel("FP_BR 2", "Foreslå beregningsgrunnlag for selvstendig næringsdrivende",
-            Arrays.asList(new FastsettBeregningsperiodeForAktivitetstatus(AktivitetStatus.SN), new SettHjemmelSN(), new BeregnOppjustertInntektForAktivitetstatus(AktivitetStatus.SN), new BeregnGjennomsnittligPGIForAktivitetstatus(AktivitetStatus.SN)), erBeregningsgrunnlagetBesteberegnet);
+            Arrays.asList(new FastsettBeregningsperiodeForAktivitetstatus(AktivitetStatus.SN), new SettHjemmelSN(),
+                new BeregnOppjustertInntektForAktivitetstatus(AktivitetStatus.SN),
+                new BeregnGjennomsnittligPGIForAktivitetstatus(AktivitetStatus.SN)), erBeregningsgrunnlagetBesteberegnet);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/vurder/frisinn/RegelVurderBeregningsgrunnlagFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/vurder/frisinn/RegelVurderBeregningsgrunnlagFRISINN.java
@@ -21,7 +21,6 @@ public class RegelVurderBeregningsgrunnlagFRISINN implements EksportRegel<Beregn
     public Specification<BeregningsgrunnlagPeriode> getSpecification() {
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
         var sjekkMindreEnnTreKvartG = rs.beregningHvisRegel(new SjekkBeregningsgrunnlagFLSNMindreEnnFRISINN(), new AvslagUnderTreKvartG(), new Beregnet());
-        return rs.beregningHvisRegel(new SjekkFrilansUtenInntekt(), new AvslagFrilansUtenInntekt(),
-            sjekkMindreEnnTreKvartG);
+        return rs.beregningHvisRegel(new SjekkFrilansUtenInntekt(), new AvslagFrilansUtenInntekt(), sjekkMindreEnnTreKvartG);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/vurder/frisinn/RegelVurderBeregningsgrunnlagFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/vurder/frisinn/RegelVurderBeregningsgrunnlagFRISINN.java
@@ -21,8 +21,7 @@ public class RegelVurderBeregningsgrunnlagFRISINN implements EksportRegel<Beregn
     public Specification<BeregningsgrunnlagPeriode> getSpecification() {
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
         var sjekkMindreEnnTreKvartG = rs.beregningHvisRegel(new SjekkBeregningsgrunnlagFLSNMindreEnnFRISINN(), new AvslagUnderTreKvartG(), new Beregnet());
-        var sjekkFrilansUtenInntekt = rs.beregningHvisRegel(new SjekkFrilansUtenInntekt(), new AvslagFrilansUtenInntekt(), // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(new SjekkFrilansUtenInntekt(), new AvslagFrilansUtenInntekt(),
             sjekkMindreEnnTreKvartG);
-        return sjekkFrilansUtenInntekt;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/vurder/frisinn/RegelVurderBeregningsgrunnlagFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/vurder/frisinn/RegelVurderBeregningsgrunnlagFRISINN.java
@@ -21,7 +21,8 @@ public class RegelVurderBeregningsgrunnlagFRISINN implements EksportRegel<Beregn
     public Specification<BeregningsgrunnlagPeriode> getSpecification() {
         var rs = new Ruleset<BeregningsgrunnlagPeriode>();
         var sjekkMindreEnnTreKvartG = rs.beregningHvisRegel(new SjekkBeregningsgrunnlagFLSNMindreEnnFRISINN(), new AvslagUnderTreKvartG(), new Beregnet());
-        var sjekkFrilansUtenInntekt = rs.beregningHvisRegel(new SjekkFrilansUtenInntekt(), new AvslagFrilansUtenInntekt(), sjekkMindreEnnTreKvartG);
+        var sjekkFrilansUtenInntekt = rs.beregningHvisRegel(new SjekkFrilansUtenInntekt(), new AvslagFrilansUtenInntekt(), // NOSONAR: java:S1488
+            sjekkMindreEnnTreKvartG);
         return sjekkFrilansUtenInntekt;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/RegelBeregnBruttoYtelseAndel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/RegelBeregnBruttoYtelseAndel.java
@@ -31,8 +31,6 @@ public class RegelBeregnBruttoYtelseAndel implements RuleService<Beregningsgrunn
 						new BeregnFraYtelsevedtak(statusAndel), new Beregnet());
 		// FP_BR 14.1 Er bruker arbeidstaker?
 
-        return rs.beregningHvisRegel(new SjekkHarSaksbehandlerSattInntektFraYtelseManuelt(statusAndel),
-						new Beregnet(),
-						fastsettFraYtelsevedtak);
+        return rs.beregningHvisRegel(new SjekkHarSaksbehandlerSattInntektFraYtelseManuelt(statusAndel), new Beregnet(), fastsettFraYtelsevedtak);
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/RegelBeregnBruttoYtelseAndel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/RegelBeregnBruttoYtelseAndel.java
@@ -31,11 +31,8 @@ public class RegelBeregnBruttoYtelseAndel implements RuleService<Beregningsgrunn
 						new BeregnFraYtelsevedtak(statusAndel), new Beregnet());
 		// FP_BR 14.1 Er bruker arbeidstaker?
 
-        var fastsettBruttoBeregningsgrunnlag =
-				rs.beregningHvisRegel(new SjekkHarSaksbehandlerSattInntektFraYtelseManuelt(statusAndel),  // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(new SjekkHarSaksbehandlerSattInntektFraYtelseManuelt(statusAndel),
 						new Beregnet(),
 						fastsettFraYtelsevedtak);
-
-		return fastsettBruttoBeregningsgrunnlag;
 	}
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/RegelBeregnBruttoYtelseAndel.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/RegelBeregnBruttoYtelseAndel.java
@@ -32,7 +32,7 @@ public class RegelBeregnBruttoYtelseAndel implements RuleService<Beregningsgrunn
 		// FP_BR 14.1 Er bruker arbeidstaker?
 
         var fastsettBruttoBeregningsgrunnlag =
-				rs.beregningHvisRegel(new SjekkHarSaksbehandlerSattInntektFraYtelseManuelt(statusAndel),
+				rs.beregningHvisRegel(new SjekkHarSaksbehandlerSattInntektFraYtelseManuelt(statusAndel),  // NOSONAR: java:S1488
 						new Beregnet(),
 						fastsettFraYtelsevedtak);
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAP.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAP.java
@@ -36,8 +36,8 @@ public class RegelFastsettBeregningsgrunnlagDPellerAAP implements RuleService<Be
             new FastsettDagpengerManueltEtterBesteberegning(), foreslåBeregningsgrunnlag);
 
         //FP_BR 10.5 Er beregnngsgrunnlag for AAP fastsatt manuelt?
-        var aapFastsattManuelt = // NOSONAR: java:S1488
-            rs.beregningHvisRegel(new SjekkOmBGForAAPFastsattManuelt(), new FastsettAAPManuelt(), dagpengerFastsattManuelt);
+        var aapFastsattManuelt = rs.beregningHvisRegel( // NOSONAR: java:S1488
+            new SjekkOmBGForAAPFastsattManuelt(), new FastsettAAPManuelt(), dagpengerFastsattManuelt);
 
         return aapFastsattManuelt;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAP.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAP.java
@@ -36,9 +36,7 @@ public class RegelFastsettBeregningsgrunnlagDPellerAAP implements RuleService<Be
             new FastsettDagpengerManueltEtterBesteberegning(), foreslåBeregningsgrunnlag);
 
         //FP_BR 10.5 Er beregnngsgrunnlag for AAP fastsatt manuelt?
-        var aapFastsattManuelt = rs.beregningHvisRegel( // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(
             new SjekkOmBGForAAPFastsattManuelt(), new FastsettAAPManuelt(), dagpengerFastsattManuelt);
-
-        return aapFastsattManuelt;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAP.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAP.java
@@ -36,7 +36,6 @@ public class RegelFastsettBeregningsgrunnlagDPellerAAP implements RuleService<Be
             new FastsettDagpengerManueltEtterBesteberegning(), foreslåBeregningsgrunnlag);
 
         //FP_BR 10.5 Er beregnngsgrunnlag for AAP fastsatt manuelt?
-        return rs.beregningHvisRegel(
-            new SjekkOmBGForAAPFastsattManuelt(), new FastsettAAPManuelt(), dagpengerFastsattManuelt);
+        return rs.beregningHvisRegel(new SjekkOmBGForAAPFastsattManuelt(), new FastsettAAPManuelt(), dagpengerFastsattManuelt);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAP.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAP.java
@@ -36,8 +36,8 @@ public class RegelFastsettBeregningsgrunnlagDPellerAAP implements RuleService<Be
             new FastsettDagpengerManueltEtterBesteberegning(), foreslåBeregningsgrunnlag);
 
         //FP_BR 10.5 Er beregnngsgrunnlag for AAP fastsatt manuelt?
-        var aapFastsattManuelt = rs.beregningHvisRegel(new SjekkOmBGForAAPFastsattManuelt(),
-            new FastsettAAPManuelt(), dagpengerFastsattManuelt);
+        var aapFastsattManuelt = // NOSONAR: java:S1488
+            rs.beregningHvisRegel(new SjekkOmBGForAAPFastsattManuelt(), new FastsettAAPManuelt(), dagpengerFastsattManuelt);
 
         return aapFastsattManuelt;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFinnGrenseverdiFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFinnGrenseverdiFRISINN.java
@@ -37,12 +37,9 @@ public class RegelFinnGrenseverdiFRISINN implements EksportRegel<Beregningsgrunn
         Specification<BeregningsgrunnlagPeriode> settGrenseverdiTilNull = new SettGrenseverdiTilNull();
 
         // FRISINN 6.10: Er vilkår oppfylt?
-        var erVilkårOppfylt = rs.beregningHvisRegel(  // NOSONAR: java:S1488
+        return rs.beregningHvisRegel(
             new ErVilkårOppfylt(),
             beregnEventuellAvkorting,
             settGrenseverdiTilNull);
-
-
-        return erVilkårOppfylt;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFinnGrenseverdiFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFinnGrenseverdiFRISINN.java
@@ -37,7 +37,7 @@ public class RegelFinnGrenseverdiFRISINN implements EksportRegel<Beregningsgrunn
         Specification<BeregningsgrunnlagPeriode> settGrenseverdiTilNull = new SettGrenseverdiTilNull();
 
         // FRISINN 6.10: Er vilkår oppfylt?
-        var erVilkårOppfylt = rs.beregningHvisRegel(
+        var erVilkårOppfylt = rs.beregningHvisRegel(  // NOSONAR: java:S1488
             new ErVilkårOppfylt(),
             beregnEventuellAvkorting,
             settGrenseverdiTilNull);

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFinnGrenseverdiFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFinnGrenseverdiFRISINN.java
@@ -37,9 +37,6 @@ public class RegelFinnGrenseverdiFRISINN implements EksportRegel<Beregningsgrunn
         Specification<BeregningsgrunnlagPeriode> settGrenseverdiTilNull = new SettGrenseverdiTilNull();
 
         // FRISINN 6.10: Er vilkår oppfylt?
-        return rs.beregningHvisRegel(
-            new ErVilkårOppfylt(),
-            beregnEventuellAvkorting,
-            settGrenseverdiTilNull);
+        return rs.beregningHvisRegel(new ErVilkårOppfylt(), beregnEventuellAvkorting, settGrenseverdiTilNull);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFullføreBeregningsgrunnlagFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFullføreBeregningsgrunnlagFRISINN.java
@@ -28,7 +28,6 @@ public class RegelFullføreBeregningsgrunnlagFRISINN implements EksportRegel<Ber
         var fastsettForFrilans = rs.beregningsRegel(FastsettForFrilans.ID, FastsettForFrilans.BESKRIVELSE,
                 new FastsettForFrilans(), fastsettForSN);
 
-        return rs.beregningsRegel(
-                FastsettIkkeSøktForTil0.ID, FastsettIkkeSøktForTil0.BESKRIVELSE, new FastsettIkkeSøktForTil0(), fastsettForFrilans);
+        return rs.beregningsRegel(FastsettIkkeSøktForTil0.ID, FastsettIkkeSøktForTil0.BESKRIVELSE, new FastsettIkkeSøktForTil0(), fastsettForFrilans);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFullføreBeregningsgrunnlagFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFullføreBeregningsgrunnlagFRISINN.java
@@ -28,8 +28,8 @@ public class RegelFullføreBeregningsgrunnlagFRISINN implements EksportRegel<Ber
         var fastsettForFrilans = rs.beregningsRegel(FastsettForFrilans.ID, FastsettForFrilans.BESKRIVELSE,
                 new FastsettForFrilans(), fastsettForSN);
 
-        var fastsettIkkeSøktForTilNull = rs.beregningsRegel(FastsettIkkeSøktForTil0.ID, FastsettIkkeSøktForTil0.BESKRIVELSE,
-                new FastsettIkkeSøktForTil0(), fastsettForFrilans);
+        var fastsettIkkeSøktForTilNull =  // NOSONAR: java:S1488
+            rs.beregningsRegel(FastsettIkkeSøktForTil0.ID, FastsettIkkeSøktForTil0.BESKRIVELSE, new FastsettIkkeSøktForTil0(), fastsettForFrilans);
 
         return fastsettIkkeSøktForTilNull;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFullføreBeregningsgrunnlagFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFullføreBeregningsgrunnlagFRISINN.java
@@ -28,8 +28,8 @@ public class RegelFullføreBeregningsgrunnlagFRISINN implements EksportRegel<Ber
         var fastsettForFrilans = rs.beregningsRegel(FastsettForFrilans.ID, FastsettForFrilans.BESKRIVELSE,
                 new FastsettForFrilans(), fastsettForSN);
 
-        var fastsettIkkeSøktForTilNull =  // NOSONAR: java:S1488
-            rs.beregningsRegel(FastsettIkkeSøktForTil0.ID, FastsettIkkeSøktForTil0.BESKRIVELSE, new FastsettIkkeSøktForTil0(), fastsettForFrilans);
+        var fastsettIkkeSøktForTilNull = rs.beregningsRegel( // NOSONAR: java:S1488
+                FastsettIkkeSøktForTil0.ID, FastsettIkkeSøktForTil0.BESKRIVELSE, new FastsettIkkeSøktForTil0(), fastsettForFrilans);
 
         return fastsettIkkeSøktForTilNull;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFullføreBeregningsgrunnlagFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/frisinn/RegelFullføreBeregningsgrunnlagFRISINN.java
@@ -28,9 +28,7 @@ public class RegelFullføreBeregningsgrunnlagFRISINN implements EksportRegel<Ber
         var fastsettForFrilans = rs.beregningsRegel(FastsettForFrilans.ID, FastsettForFrilans.BESKRIVELSE,
                 new FastsettForFrilans(), fastsettForSN);
 
-        var fastsettIkkeSøktForTilNull = rs.beregningsRegel( // NOSONAR: java:S1488
+        return rs.beregningsRegel(
                 FastsettIkkeSøktForTil0.ID, FastsettIkkeSøktForTil0.BESKRIVELSE, new FastsettIkkeSøktForTil0(), fastsettForFrilans);
-
-        return fastsettIkkeSøktForTilNull;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/besteberegning/RegelForeslåBesteberegning.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/besteberegning/RegelForeslåBesteberegning.java
@@ -28,7 +28,7 @@ public class RegelForeslåBesteberegning implements EksportRegel<BesteberegningR
 				new ErSeksBesteMånederBedre());
 
 
-        var foreslåBesteberegning = rs.beregningsRegel(
+        var foreslåBesteberegning = rs.beregningsRegel(  // NOSONAR: java:S1488
 				FinnBesteMåneder.ID,
 				FinnBesteMåneder.BESKRIVELSE,
 				new FinnBesteMåneder(),

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/besteberegning/RegelForeslåBesteberegning.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/besteberegning/RegelForeslåBesteberegning.java
@@ -28,13 +28,11 @@ public class RegelForeslåBesteberegning implements EksportRegel<BesteberegningR
 				new ErSeksBesteMånederBedre());
 
 
-        var foreslåBesteberegning = rs.beregningsRegel(  // NOSONAR: java:S1488
+        return rs.beregningsRegel(
 				FinnBesteMåneder.ID,
 				FinnBesteMåneder.BESKRIVELSE,
 				new FinnBesteMåneder(),
 				fastsettBesteberegning);
-
-		return foreslåBesteberegning;
 	}
 
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/regel/RegelFastsettSkjæringstidspunkt.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/regel/RegelFastsettSkjæringstidspunkt.java
@@ -47,8 +47,9 @@ public class RegelFastsettSkjæringstidspunkt implements EksportRegel<AktivitetS
 
 //      FP_BR 21.8 Er siste aktivitet før skjæringstidspunkt for opptjening, militær eller obligatorisk sivilforvarstjeneste og er dette brukers eneste aktivitet på dette tidspunktet Og har bruker andre aktiviteter i opptjeningsperioden
 
-        var startFastsettSkjæringstidspunktForBeregning =
-            rs.beregningHvisRegel(new SjekkOmMilitærErSisteOgEnesteAktivitet(), førsteDagEtterAktivitetSomIkkeErMilitær, erDetAktivitetFremTilStpForOpptjening);
+        var startFastsettSkjæringstidspunktForBeregning = // NOSONAR: java:S1488
+            rs.beregningHvisRegel(new SjekkOmMilitærErSisteOgEnesteAktivitet(), førsteDagEtterAktivitetSomIkkeErMilitær,
+                erDetAktivitetFremTilStpForOpptjening);
 
         return startFastsettSkjæringstidspunktForBeregning;
     }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/regel/RegelFastsettSkjæringstidspunkt.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/regel/RegelFastsettSkjæringstidspunkt.java
@@ -48,6 +48,6 @@ public class RegelFastsettSkjæringstidspunkt implements EksportRegel<AktivitetS
 //      FP_BR 21.8 Er siste aktivitet før skjæringstidspunkt for opptjening, militær eller obligatorisk sivilforvarstjeneste og er dette brukers eneste aktivitet på dette tidspunktet Og har bruker andre aktiviteter i opptjeningsperioden
 
         return rs.beregningHvisRegel(new SjekkOmMilitærErSisteOgEnesteAktivitet(), førsteDagEtterAktivitetSomIkkeErMilitær,
-                erDetAktivitetFremTilStpForOpptjening);
+            erDetAktivitetFremTilStpForOpptjening);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/regel/RegelFastsettSkjæringstidspunkt.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/regel/RegelFastsettSkjæringstidspunkt.java
@@ -47,10 +47,7 @@ public class RegelFastsettSkjæringstidspunkt implements EksportRegel<AktivitetS
 
 //      FP_BR 21.8 Er siste aktivitet før skjæringstidspunkt for opptjening, militær eller obligatorisk sivilforvarstjeneste og er dette brukers eneste aktivitet på dette tidspunktet Og har bruker andre aktiviteter i opptjeningsperioden
 
-        var startFastsettSkjæringstidspunktForBeregning = // NOSONAR: java:S1488
-            rs.beregningHvisRegel(new SjekkOmMilitærErSisteOgEnesteAktivitet(), førsteDagEtterAktivitetSomIkkeErMilitær,
+        return rs.beregningHvisRegel(new SjekkOmMilitærErSisteOgEnesteAktivitet(), førsteDagEtterAktivitetSomIkkeErMilitær,
                 erDetAktivitetFremTilStpForOpptjening);
-
-        return startFastsettSkjæringstidspunktForBeregning;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/RegelFastsettStatusVedSkjæringstidspunkt.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/RegelFastsettStatusVedSkjæringstidspunkt.java
@@ -43,12 +43,7 @@ public class RegelFastsettStatusVedSkjæringstidspunkt implements EksportRegel<A
 //      FP_BR_19_1 Hent aktiviteter på skjæringstidspunkt
 //      FP_BR_19_2 Fastsett status per andel og periode
 
-        var startFastsettStatusVedSkjæringtidspunktForBeregning =  // NOSONAR: java:S1488
-            rs.beregningsRegel(FastsettStatusOgAndelPrPeriode.ID, FastsettStatusOgAndelPrPeriode.BESKRIVELSE, new FastsettStatusOgAndelPrPeriode(),
+        return rs.beregningsRegel(FastsettStatusOgAndelPrPeriode.ID, FastsettStatusOgAndelPrPeriode.BESKRIVELSE, new FastsettStatusOgAndelPrPeriode(),
                 sjekkAktuelleKombinasjoner);
-
-//      Start fastsett status ved skjæringstidspunkt for beregning
-
-        return startFastsettStatusVedSkjæringtidspunktForBeregning;
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/RegelFastsettStatusVedSkjæringstidspunkt.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/RegelFastsettStatusVedSkjæringstidspunkt.java
@@ -44,6 +44,6 @@ public class RegelFastsettStatusVedSkjæringstidspunkt implements EksportRegel<A
 //      FP_BR_19_2 Fastsett status per andel og periode
 
         return rs.beregningsRegel(FastsettStatusOgAndelPrPeriode.ID, FastsettStatusOgAndelPrPeriode.BESKRIVELSE, new FastsettStatusOgAndelPrPeriode(),
-                sjekkAktuelleKombinasjoner);
+            sjekkAktuelleKombinasjoner);
     }
 }

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/RegelFastsettStatusVedSkjæringstidspunkt.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/RegelFastsettStatusVedSkjæringstidspunkt.java
@@ -43,9 +43,9 @@ public class RegelFastsettStatusVedSkjæringstidspunkt implements EksportRegel<A
 //      FP_BR_19_1 Hent aktiviteter på skjæringstidspunkt
 //      FP_BR_19_2 Fastsett status per andel og periode
 
-        var startFastsettStatusVedSkjæringtidspunktForBeregning =
-            rs.beregningsRegel(FastsettStatusOgAndelPrPeriode.ID, FastsettStatusOgAndelPrPeriode.BESKRIVELSE,
-                new FastsettStatusOgAndelPrPeriode(), sjekkAktuelleKombinasjoner);
+        var startFastsettStatusVedSkjæringtidspunktForBeregning =  // NOSONAR: java:S1488
+            rs.beregningsRegel(FastsettStatusOgAndelPrPeriode.ID, FastsettStatusOgAndelPrPeriode.BESKRIVELSE, new FastsettStatusOgAndelPrPeriode(),
+                sjekkAktuelleKombinasjoner);
 
 //      Start fastsett status ved skjæringstidspunkt for beregning
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/frisinn/RegelFastsettStatusVedSkjæringstidspunktFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/frisinn/RegelFastsettStatusVedSkjæringstidspunktFRISINN.java
@@ -43,7 +43,7 @@ public class RegelFastsettStatusVedSkjæringstidspunktFRISINN implements Eksport
 //      FP_BR_19_1 Hent aktiviteter på skjæringstidspunkt
 //      FP_BR_19_2 Fastsett status per andel og periode
 
-        var startFastsettStatusVedSkjæringtidspunktForBeregning =
+        var startFastsettStatusVedSkjæringtidspunktForBeregning =  // NOSONAR: java:S1488
             rs.beregningsRegel(FastsettStatusOgAndelPrPeriodeFRISINN.ID, FastsettStatusOgAndelPrPeriodeFRISINN.BESKRIVELSE,
                 new FastsettStatusOgAndelPrPeriodeFRISINN(), sjekkAktuelleKombinasjoner);
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/frisinn/RegelFastsettStatusVedSkjæringstidspunktFRISINN.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/skjæringstidspunkt/status/frisinn/RegelFastsettStatusVedSkjæringstidspunktFRISINN.java
@@ -43,12 +43,7 @@ public class RegelFastsettStatusVedSkjæringstidspunktFRISINN implements Eksport
 //      FP_BR_19_1 Hent aktiviteter på skjæringstidspunkt
 //      FP_BR_19_2 Fastsett status per andel og periode
 
-        var startFastsettStatusVedSkjæringtidspunktForBeregning =  // NOSONAR: java:S1488
-            rs.beregningsRegel(FastsettStatusOgAndelPrPeriodeFRISINN.ID, FastsettStatusOgAndelPrPeriodeFRISINN.BESKRIVELSE,
+        return rs.beregningsRegel(FastsettStatusOgAndelPrPeriodeFRISINN.ID, FastsettStatusOgAndelPrPeriodeFRISINN.BESKRIVELSE,
                 new FastsettStatusOgAndelPrPeriodeFRISINN(), sjekkAktuelleKombinasjoner);
-
-//      Start fastsett status ved skjæringstidspunkt for beregning
-
-        return startFastsettStatusVedSkjæringtidspunktForBeregning;
     }
 }

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/fastsett/MapFullføreBeregningsgrunnlagFraVLTilRegel.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/fastsett/MapFullføreBeregningsgrunnlagFraVLTilRegel.java
@@ -113,11 +113,9 @@ public class MapFullføreBeregningsgrunnlagFraVLTilRegel {
     private static List<BeregningsgrunnlagPeriode> mapBeregningsgrunnlagPerioder(BeregningsgrunnlagDto vlBeregningsgrunnlag,
                                                                                  BeregningsgrunnlagInput input) {
         var perioderTilVurderingTjeneste = new PerioderTilVurderingTjeneste(input.getForlengelseperioder(), vlBeregningsgrunnlag);
-        var perioder = vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()  // NOSONAR: java:S1488
+        return vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()
                 .filter(p -> perioderTilVurderingTjeneste.erTilVurdering(p.getPeriode()))
                 .map(vlBGPeriode -> mapPeriode(vlBGPeriode, input)).toList();
-
-        return perioder;
     }
 
     private static BeregningsgrunnlagPeriode mapPeriode(BeregningsgrunnlagPeriodeDto vlBGPeriode, BeregningsgrunnlagInput input) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/fastsett/MapFullføreBeregningsgrunnlagFraVLTilRegel.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/fastsett/MapFullføreBeregningsgrunnlagFraVLTilRegel.java
@@ -113,7 +113,7 @@ public class MapFullføreBeregningsgrunnlagFraVLTilRegel {
     private static List<BeregningsgrunnlagPeriode> mapBeregningsgrunnlagPerioder(BeregningsgrunnlagDto vlBeregningsgrunnlag,
                                                                                  BeregningsgrunnlagInput input) {
         var perioderTilVurderingTjeneste = new PerioderTilVurderingTjeneste(input.getForlengelseperioder(), vlBeregningsgrunnlag);
-        var perioder = vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()
+        var perioder = vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()  // NOSONAR: java:S1488
                 .filter(p -> perioderTilVurderingTjeneste.erTilVurdering(p.getPeriode()))
                 .map(vlBGPeriode -> mapPeriode(vlBGPeriode, input)).toList();
 

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/fastsett/MapFullføreBeregningsgrunnlagFraVLTilRegel.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/fastsett/MapFullføreBeregningsgrunnlagFraVLTilRegel.java
@@ -113,9 +113,11 @@ public class MapFullføreBeregningsgrunnlagFraVLTilRegel {
     private static List<BeregningsgrunnlagPeriode> mapBeregningsgrunnlagPerioder(BeregningsgrunnlagDto vlBeregningsgrunnlag,
                                                                                  BeregningsgrunnlagInput input) {
         var perioderTilVurderingTjeneste = new PerioderTilVurderingTjeneste(input.getForlengelseperioder(), vlBeregningsgrunnlag);
-        return vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()
-                .filter(p -> perioderTilVurderingTjeneste.erTilVurdering(p.getPeriode()))
-                .map(vlBGPeriode -> mapPeriode(vlBGPeriode, input)).toList();
+        return vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder()
+            .stream()
+            .filter(p -> perioderTilVurderingTjeneste.erTilVurdering(p.getPeriode()))
+            .map(vlBGPeriode -> mapPeriode(vlBGPeriode, input))
+            .toList();
     }
 
     private static BeregningsgrunnlagPeriode mapPeriode(BeregningsgrunnlagPeriodeDto vlBGPeriode, BeregningsgrunnlagInput input) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/MapBeregningsgrunnlagFraVLTilRegel.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/MapBeregningsgrunnlagFraVLTilRegel.java
@@ -113,7 +113,7 @@ public class MapBeregningsgrunnlagFraVLTilRegel {
     private static List<BeregningsgrunnlagPeriode> mapBeregningsgrunnlagPerioder(BeregningsgrunnlagDto vlBeregningsgrunnlag,
                                                                                  BeregningsgrunnlagInput input) {
         var perioderTilVurderingTjeneste = new PerioderTilVurderingTjeneste(input.getForlengelseperioder(), vlBeregningsgrunnlag);
-        var perioder = vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()
+        var perioder = vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()  // NOSONAR: java:S1488
                 .filter(p -> perioderTilVurderingTjeneste.erTilVurdering(p.getPeriode()))
                 .map(vlBGPeriode -> mapPeriode(vlBGPeriode, input)).toList();
 

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/MapBeregningsgrunnlagFraVLTilRegel.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/MapBeregningsgrunnlagFraVLTilRegel.java
@@ -114,8 +114,8 @@ public class MapBeregningsgrunnlagFraVLTilRegel {
                                                                                  BeregningsgrunnlagInput input) {
         var perioderTilVurderingTjeneste = new PerioderTilVurderingTjeneste(input.getForlengelseperioder(), vlBeregningsgrunnlag);
         return vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()
-                .filter(p -> perioderTilVurderingTjeneste.erTilVurdering(p.getPeriode()))
-                .map(vlBGPeriode -> mapPeriode(vlBGPeriode, input)).toList();
+            .filter(p -> perioderTilVurderingTjeneste.erTilVurdering(p.getPeriode()))
+            .map(vlBGPeriode -> mapPeriode(vlBGPeriode, input)).toList();
     }
 
     private static BeregningsgrunnlagPeriode mapPeriode(BeregningsgrunnlagPeriodeDto vlBGPeriode, BeregningsgrunnlagInput input) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/MapBeregningsgrunnlagFraVLTilRegel.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/MapBeregningsgrunnlagFraVLTilRegel.java
@@ -113,11 +113,9 @@ public class MapBeregningsgrunnlagFraVLTilRegel {
     private static List<BeregningsgrunnlagPeriode> mapBeregningsgrunnlagPerioder(BeregningsgrunnlagDto vlBeregningsgrunnlag,
                                                                                  BeregningsgrunnlagInput input) {
         var perioderTilVurderingTjeneste = new PerioderTilVurderingTjeneste(input.getForlengelseperioder(), vlBeregningsgrunnlag);
-        var perioder = vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()  // NOSONAR: java:S1488
+        return vlBeregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()
                 .filter(p -> perioderTilVurderingTjeneste.erTilVurdering(p.getPeriode()))
                 .map(vlBGPeriode -> mapPeriode(vlBGPeriode, input)).toList();
-
-        return perioder;
     }
 
     private static BeregningsgrunnlagPeriode mapPeriode(BeregningsgrunnlagPeriodeDto vlBGPeriode, BeregningsgrunnlagInput input) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/SimulerGraderingMotInntektTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/SimulerGraderingMotInntektTjeneste.java
@@ -292,11 +292,11 @@ public class SimulerGraderingMotInntektTjeneste {
             return Beløp.ZERO;
         }
         return aktuellePoster.stream()
-                .map(post -> finnBruttoInntektFraInntektspost(arbeidsgiver, arbeidsforholdRef, ytelsespesifiktGrunnlag, post))
-                .filter(Objects::nonNull)
-                .reduce(Beløp::adder)
-                .orElse(Beløp.ZERO)
-                .divider(antallPoster, 10, RoundingMode.HALF_UP);
+            .map(post -> finnBruttoInntektFraInntektspost(arbeidsgiver, arbeidsforholdRef, ytelsespesifiktGrunnlag, post))
+            .filter(Objects::nonNull)
+            .reduce(Beløp::adder)
+            .orElse(Beløp.ZERO)
+            .divider(antallPoster, 10, RoundingMode.HALF_UP);
     }
 
     private Beløp finnInntektForFrilans(Intervall periode,

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/SimulerGraderingMotInntektTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/SimulerGraderingMotInntektTjeneste.java
@@ -291,13 +291,12 @@ public class SimulerGraderingMotInntektTjeneste {
         if (antallPoster == 0) {
             return Beløp.ZERO;
         }
-        var beløp = aktuellePoster.stream()  // NOSONAR: java:S1488
+        return aktuellePoster.stream()
                 .map(post -> finnBruttoInntektFraInntektspost(arbeidsgiver, arbeidsforholdRef, ytelsespesifiktGrunnlag, post))
                 .filter(Objects::nonNull)
                 .reduce(Beløp::adder)
                 .orElse(Beløp.ZERO)
                 .divider(antallPoster, 10, RoundingMode.HALF_UP);
-        return beløp;
     }
 
     private Beløp finnInntektForFrilans(Intervall periode,

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/SimulerGraderingMotInntektTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/felles/inntektgradering/SimulerGraderingMotInntektTjeneste.java
@@ -291,7 +291,7 @@ public class SimulerGraderingMotInntektTjeneste {
         if (antallPoster == 0) {
             return Beløp.ZERO;
         }
-        var beløp = aktuellePoster.stream()
+        var beløp = aktuellePoster.stream()  // NOSONAR: java:S1488
                 .map(post -> finnBruttoInntektFraInntektspost(arbeidsgiver, arbeidsforholdRef, ytelsespesifiktGrunnlag, post))
                 .filter(Objects::nonNull)
                 .reduce(Beløp::adder)

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/FordelBeregningsgrunnlagDtoTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/FordelBeregningsgrunnlagDtoTjeneste.java
@@ -42,8 +42,8 @@ public class FordelBeregningsgrunnlagDtoTjeneste {
         var beregningsgrunnlag = input.getBeregningsgrunnlag();
         var bgPerioder = beregningsgrunnlag.getBeregningsgrunnlagPerioder();
         return bgPerioder.stream()
-                .map(periode -> mapTilPeriodeDto(input, periode, beregningsgrunnlag.getGrunnbeløp()))
-                .sorted(Comparator.comparing(FordelBeregningsgrunnlagPeriodeDto::getFom)).collect(toList());
+            .map(periode -> mapTilPeriodeDto(input, periode, beregningsgrunnlag.getGrunnbeløp()))
+            .sorted(Comparator.comparing(FordelBeregningsgrunnlagPeriodeDto::getFom)).collect(toList());
     }
 
     private static FordelBeregningsgrunnlagPeriodeDto mapTilPeriodeDto(BeregningsgrunnlagGUIInput input,

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/FordelBeregningsgrunnlagDtoTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/FordelBeregningsgrunnlagDtoTjeneste.java
@@ -41,7 +41,7 @@ public class FordelBeregningsgrunnlagDtoTjeneste {
     private static List<FordelBeregningsgrunnlagPeriodeDto> lagPerioder(BeregningsgrunnlagGUIInput input) {
         var beregningsgrunnlag = input.getBeregningsgrunnlag();
         var bgPerioder = beregningsgrunnlag.getBeregningsgrunnlagPerioder();
-        var fordelPerioder = bgPerioder.stream()
+        var fordelPerioder = bgPerioder.stream()  // NOSONAR: java:S1488
                 .map(periode -> mapTilPeriodeDto(input, periode, beregningsgrunnlag.getGrunnbeløp()))
                 .sorted(Comparator.comparing(FordelBeregningsgrunnlagPeriodeDto::getFom)).collect(toList());
         return fordelPerioder;

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/FordelBeregningsgrunnlagDtoTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/FordelBeregningsgrunnlagDtoTjeneste.java
@@ -41,10 +41,9 @@ public class FordelBeregningsgrunnlagDtoTjeneste {
     private static List<FordelBeregningsgrunnlagPeriodeDto> lagPerioder(BeregningsgrunnlagGUIInput input) {
         var beregningsgrunnlag = input.getBeregningsgrunnlag();
         var bgPerioder = beregningsgrunnlag.getBeregningsgrunnlagPerioder();
-        var fordelPerioder = bgPerioder.stream()  // NOSONAR: java:S1488
+        return bgPerioder.stream()
                 .map(periode -> mapTilPeriodeDto(input, periode, beregningsgrunnlag.getGrunnbeløp()))
                 .sorted(Comparator.comparing(FordelBeregningsgrunnlagPeriodeDto::getFom)).collect(toList());
-        return fordelPerioder;
     }
 
     private static FordelBeregningsgrunnlagPeriodeDto mapTilPeriodeDto(BeregningsgrunnlagGUIInput input,

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/beregningsgrunnlag/BeregningsgrunnlagDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/beregningsgrunnlag/BeregningsgrunnlagDto.java
@@ -42,7 +42,7 @@ public class BeregningsgrunnlagDto {
 
         this.sammenligningsgrunnlagPrStatusListe = kopiereFra.getSammenligningsgrunnlagPrStatusListe().stream().map(s -> {
 	        var builder = SammenligningsgrunnlagPrStatusDto.Builder.kopier(s);
-	        var build = builder.build();
+	        var build = builder.build();  // NOSONAR: java:S1488
             return build;
         }).collect(Collectors.toList());
 

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/beregningsgrunnlag/BeregningsgrunnlagDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/beregningsgrunnlag/BeregningsgrunnlagDto.java
@@ -42,8 +42,7 @@ public class BeregningsgrunnlagDto {
 
         this.sammenligningsgrunnlagPrStatusListe = kopiereFra.getSammenligningsgrunnlagPrStatusListe().stream().map(s -> {
 	        var builder = SammenligningsgrunnlagPrStatusDto.Builder.kopier(s);
-	        var build = builder.build();  // NOSONAR: java:S1488
-            return build;
+	        return builder.build();
         }).collect(Collectors.toList());
 
         this.beregningsgrunnlagPerioder = kopiereFra.getBeregningsgrunnlagPerioder().stream().map(p -> {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/InntektsmeldingDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/InntektsmeldingDto.java
@@ -39,12 +39,10 @@ public class InntektsmeldingDto {
         this.refusjonBeløpPerMnd = inntektsmelding.getRefusjonBeløpPerMnd();
         this.refusjonOpphører = inntektsmelding.getRefusjonOpphører();
         this.naturalYtelser = inntektsmelding.getNaturalYtelser().stream().map(n -> {
-            final var naturalYtelse = new NaturalYtelseDto(n);  // NOSONAR: java:S1488
-            return naturalYtelse;
+            return new NaturalYtelseDto(n);
         }).collect(Collectors.toList());
         this.endringerRefusjon = inntektsmelding.getEndringerRefusjon().stream().map(r -> {
-            final var refusjon = new RefusjonDto(r);  // NOSONAR: java:S1488
-            return refusjon;
+            return new RefusjonDto(r);
         }).collect(Collectors.toList());
         this.journalpostId = inntektsmelding.getJournalpostId();
         this.inntektsmeldingType = inntektsmelding.getInntektsmeldingType();

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/InntektsmeldingDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/InntektsmeldingDto.java
@@ -38,12 +38,8 @@ public class InntektsmeldingDto {
         this.inntektBeløp = inntektsmelding.getInntektBeløp();
         this.refusjonBeløpPerMnd = inntektsmelding.getRefusjonBeløpPerMnd();
         this.refusjonOpphører = inntektsmelding.getRefusjonOpphører();
-        this.naturalYtelser = inntektsmelding.getNaturalYtelser().stream().map(n -> {
-            return new NaturalYtelseDto(n);
-        }).collect(Collectors.toList());
-        this.endringerRefusjon = inntektsmelding.getEndringerRefusjon().stream().map(r -> {
-            return new RefusjonDto(r);
-        }).collect(Collectors.toList());
+        this.naturalYtelser = inntektsmelding.getNaturalYtelser().stream().map(NaturalYtelseDto::new).collect(Collectors.toList());
+        this.endringerRefusjon = inntektsmelding.getEndringerRefusjon().stream().map(RefusjonDto::new).collect(Collectors.toList());
         this.journalpostId = inntektsmelding.getJournalpostId();
         this.inntektsmeldingType = inntektsmelding.getInntektsmeldingType();
     }

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/InntektsmeldingDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/InntektsmeldingDto.java
@@ -39,11 +39,11 @@ public class InntektsmeldingDto {
         this.refusjonBeløpPerMnd = inntektsmelding.getRefusjonBeløpPerMnd();
         this.refusjonOpphører = inntektsmelding.getRefusjonOpphører();
         this.naturalYtelser = inntektsmelding.getNaturalYtelser().stream().map(n -> {
-            final var naturalYtelse = new NaturalYtelseDto(n);
+            final var naturalYtelse = new NaturalYtelseDto(n);  // NOSONAR: java:S1488
             return naturalYtelse;
         }).collect(Collectors.toList());
         this.endringerRefusjon = inntektsmelding.getEndringerRefusjon().stream().map(r -> {
-            final var refusjon = new RefusjonDto(r);
+            final var refusjon = new RefusjonDto(r);  // NOSONAR: java:S1488
             return refusjon;
         }).collect(Collectors.toList());
         this.journalpostId = inntektsmelding.getJournalpostId();

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetDto.java
@@ -33,13 +33,11 @@ public class YrkesaktivitetDto {
 
         // NB må aksessere felt her heller en getter siden getter filtrerer
         this.aktivitetsAvtale = kopierFra.aktivitetsAvtale.stream().map(aa -> {
-            var aktivitetsAvtaleEntitet = new AktivitetsAvtaleDto(aa);  // NOSONAR: java:S1488
-            return aktivitetsAvtaleEntitet;
+            return new AktivitetsAvtaleDto(aa);
         }).collect(Collectors.toCollection(LinkedHashSet::new));
 
         this.permisjoner = kopierFra.permisjoner.stream().map(p -> {
-            var permisjon = new PermisjonDto(p);  // NOSONAR: java:S1488
-            return permisjon;
+            return new PermisjonDto(p);
         }).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
@@ -90,8 +88,7 @@ public class YrkesaktivitetDto {
      */
     public boolean gjelderFor(Arbeidsgiver arbeidsgiver, InternArbeidsforholdRefDto arbeidsforholdRef) {
         var gjelderForArbeidsgiver = Objects.equals(getArbeidsgiver(), arbeidsgiver);
-        var gjelderFor = gjelderForArbeidsgiver && getArbeidsforholdRef().gjelderFor(arbeidsforholdRef);  // NOSONAR: java:S1488
-        return gjelderFor;
+        return gjelderForArbeidsgiver && getArbeidsforholdRef().gjelderFor(arbeidsforholdRef);
     }
 
     public boolean gjelderFor(InntektsmeldingDto im) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetDto.java
@@ -33,12 +33,12 @@ public class YrkesaktivitetDto {
 
         // NB må aksessere felt her heller en getter siden getter filtrerer
         this.aktivitetsAvtale = kopierFra.aktivitetsAvtale.stream().map(aa -> {
-            var aktivitetsAvtaleEntitet = new AktivitetsAvtaleDto(aa);
+            var aktivitetsAvtaleEntitet = new AktivitetsAvtaleDto(aa);  // NOSONAR: java:S1488
             return aktivitetsAvtaleEntitet;
         }).collect(Collectors.toCollection(LinkedHashSet::new));
 
         this.permisjoner = kopierFra.permisjoner.stream().map(p -> {
-            var permisjon = new PermisjonDto(p);
+            var permisjon = new PermisjonDto(p);  // NOSONAR: java:S1488
             return permisjon;
         }).collect(Collectors.toCollection(LinkedHashSet::new));
     }
@@ -90,7 +90,7 @@ public class YrkesaktivitetDto {
      */
     public boolean gjelderFor(Arbeidsgiver arbeidsgiver, InternArbeidsforholdRefDto arbeidsforholdRef) {
         var gjelderForArbeidsgiver = Objects.equals(getArbeidsgiver(), arbeidsgiver);
-        var gjelderFor = gjelderForArbeidsgiver && getArbeidsforholdRef().gjelderFor(arbeidsforholdRef);
+        var gjelderFor = gjelderForArbeidsgiver && getArbeidsforholdRef().gjelderFor(arbeidsforholdRef);  // NOSONAR: java:S1488
         return gjelderFor;
     }
 

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetDto.java
@@ -32,13 +32,11 @@ public class YrkesaktivitetDto {
         this.arbeidsforholdRef = kopierFra.arbeidsforholdRef;
 
         // NB må aksessere felt her heller en getter siden getter filtrerer
-        this.aktivitetsAvtale = kopierFra.aktivitetsAvtale.stream().map(aa -> {
-            return new AktivitetsAvtaleDto(aa);
-        }).collect(Collectors.toCollection(LinkedHashSet::new));
+        this.aktivitetsAvtale = kopierFra.aktivitetsAvtale.stream()
+            .map(AktivitetsAvtaleDto::new)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        this.permisjoner = kopierFra.permisjoner.stream().map(p -> {
-            return new PermisjonDto(p);
-        }).collect(Collectors.toCollection(LinkedHashSet::new));
+        this.permisjoner = kopierFra.permisjoner.stream().map(PermisjonDto::new).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetFilterDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetFilterDto.java
@@ -66,7 +66,7 @@ public class YrkesaktivitetFilterDto {
     }
 
     public Collection<AktivitetsAvtaleDto> getAktivitetsAvtalerForArbeid(YrkesaktivitetDto ya) {
-        var aktivitetsAvtaler = filterAktivitetsAvtaleOverstyring(ya, internGetAktivitetsAvtalerForArbeid(ya));
+        var aktivitetsAvtaler = filterAktivitetsAvtaleOverstyring(ya, internGetAktivitetsAvtalerForArbeid(ya));  // NOSONAR: java:S1488
         return aktivitetsAvtaler;
     }
 
@@ -85,7 +85,7 @@ public class YrkesaktivitetFilterDto {
     }
 
     public Collection<YrkesaktivitetDto> getYrkesaktiviteter() {
-        var ya = getYrkesaktiviteterInklusiveFiktive().stream()
+        var ya = getYrkesaktiviteterInklusiveFiktive().stream()  // NOSONAR: java:S1488
                 .filter(this::erIkkeFrilansOppdrag)
                 .filter(this::skalBrukes)
                 .filter(it -> (erArbeidsforholdOgStarterPåRettSideAvSkjæringstidspunkt(it) || !getAktivitetsAvtalerForArbeid(it).isEmpty()))
@@ -135,7 +135,7 @@ public class YrkesaktivitetFilterDto {
     }
 
     private boolean erArbeidsforholdOgStarterPåRettSideAvSkjæringstidspunkt(YrkesaktivitetDto it) {
-        var retval = it.erArbeidsforhold()
+        var retval = it.erArbeidsforhold()  // NOSONAR: java:S1488
                 && getAnsettelsesPerioder(it).stream().anyMatch(ap -> skalMedEtterSkjæringstidspunktVurdering(ap));
         return retval;
     }
@@ -257,7 +257,7 @@ public class YrkesaktivitetFilterDto {
             var ansettelsesAvtaler = ya.getAlleAktivitetsAvtaler().stream()
                     .filter(AktivitetsAvtaleDto::erAnsettelsesPeriode)
                     .collect(Collectors.toList());
-            var filtrert = List.copyOf(filterAktivitetsAvtaleOverstyring(ya, ansettelsesAvtaler));
+            var filtrert = List.copyOf(filterAktivitetsAvtaleOverstyring(ya, ansettelsesAvtaler));  // NOSONAR: java:S1488
             return filtrert;
         }
         return Collections.emptyList();
@@ -269,7 +269,9 @@ public class YrkesaktivitetFilterDto {
      * @see #getAnsettelsesPerioder(YrkesaktivitetDto)
      */
     public Collection<AktivitetsAvtaleDto> getAnsettelsesPerioder(Collection<YrkesaktivitetDto> yrkesaktiviteter) {
-        var aktivitetsavtaler = yrkesaktiviteter.stream().flatMap(ya -> getAnsettelsesPerioder(ya).stream()).collect(Collectors.toList());
+        var aktivitetsavtaler = yrkesaktiviteter.stream()// NOSONAR: java:S1488
+            .flatMap(ya -> getAnsettelsesPerioder(ya).stream())
+            .collect(Collectors.toList());
         return aktivitetsavtaler;
     }
 
@@ -279,7 +281,9 @@ public class YrkesaktivitetFilterDto {
      * @see #getAnsettelsesPerioder(YrkesaktivitetDto)
      */
     public Collection<AktivitetsAvtaleDto> getAnsettelsesPerioder() {
-        var ansettelsesPerioder = getYrkesaktiviteterInklusiveFiktive().stream().flatMap(ya -> getAnsettelsesPerioder(ya).stream()).collect(Collectors.toList());
+        var ansettelsesPerioder = getYrkesaktiviteterInklusiveFiktive().stream() // NOSONAR: java:S1488
+            .flatMap(ya -> getAnsettelsesPerioder(ya).stream())
+            .collect(Collectors.toList());
         return ansettelsesPerioder;
     }
 

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetFilterDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetFilterDto.java
@@ -133,7 +133,7 @@ public class YrkesaktivitetFilterDto {
     }
 
     private boolean erArbeidsforholdOgStarterPåRettSideAvSkjæringstidspunkt(YrkesaktivitetDto it) {
-        return it.erArbeidsforhold() && getAnsettelsesPerioder(it).stream().anyMatch(ap -> skalMedEtterSkjæringstidspunktVurdering(ap));
+        return it.erArbeidsforhold() && getAnsettelsesPerioder(it).stream().anyMatch(this::skalMedEtterSkjæringstidspunktVurdering);
     }
 
     private boolean erFrilansOppdrag(YrkesaktivitetDto aktivitet) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetFilterDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetFilterDto.java
@@ -66,8 +66,7 @@ public class YrkesaktivitetFilterDto {
     }
 
     public Collection<AktivitetsAvtaleDto> getAktivitetsAvtalerForArbeid(YrkesaktivitetDto ya) {
-        var aktivitetsAvtaler = filterAktivitetsAvtaleOverstyring(ya, internGetAktivitetsAvtalerForArbeid(ya));  // NOSONAR: java:S1488
-        return aktivitetsAvtaler;
+        return filterAktivitetsAvtaleOverstyring(ya, internGetAktivitetsAvtalerForArbeid(ya));
     }
 
     private Set<AktivitetsAvtaleDto> internGetAktivitetsAvtalerForArbeid(YrkesaktivitetDto ya) {
@@ -85,12 +84,11 @@ public class YrkesaktivitetFilterDto {
     }
 
     public Collection<YrkesaktivitetDto> getYrkesaktiviteter() {
-        var ya = getYrkesaktiviteterInklusiveFiktive().stream()  // NOSONAR: java:S1488
+        return getYrkesaktiviteterInklusiveFiktive().stream()
                 .filter(this::erIkkeFrilansOppdrag)
                 .filter(this::skalBrukes)
                 .filter(it -> (erArbeidsforholdOgStarterPåRettSideAvSkjæringstidspunkt(it) || !getAktivitetsAvtalerForArbeid(it).isEmpty()))
                 .collect(Collectors.toUnmodifiableSet());
-        return ya;
     }
 
     /**
@@ -135,9 +133,8 @@ public class YrkesaktivitetFilterDto {
     }
 
     private boolean erArbeidsforholdOgStarterPåRettSideAvSkjæringstidspunkt(YrkesaktivitetDto it) {
-        var retval = it.erArbeidsforhold()  // NOSONAR: java:S1488
+        return it.erArbeidsforhold()
                 && getAnsettelsesPerioder(it).stream().anyMatch(ap -> skalMedEtterSkjæringstidspunktVurdering(ap));
-        return retval;
     }
 
     private boolean erFrilansOppdrag(YrkesaktivitetDto aktivitet) {
@@ -257,8 +254,7 @@ public class YrkesaktivitetFilterDto {
             var ansettelsesAvtaler = ya.getAlleAktivitetsAvtaler().stream()
                     .filter(AktivitetsAvtaleDto::erAnsettelsesPeriode)
                     .collect(Collectors.toList());
-            var filtrert = List.copyOf(filterAktivitetsAvtaleOverstyring(ya, ansettelsesAvtaler));  // NOSONAR: java:S1488
-            return filtrert;
+            return List.copyOf(filterAktivitetsAvtaleOverstyring(ya, ansettelsesAvtaler));
         }
         return Collections.emptyList();
     }
@@ -269,10 +265,9 @@ public class YrkesaktivitetFilterDto {
      * @see #getAnsettelsesPerioder(YrkesaktivitetDto)
      */
     public Collection<AktivitetsAvtaleDto> getAnsettelsesPerioder(Collection<YrkesaktivitetDto> yrkesaktiviteter) {
-        var aktivitetsavtaler = yrkesaktiviteter.stream()// NOSONAR: java:S1488
+        return yrkesaktiviteter.stream()
             .flatMap(ya -> getAnsettelsesPerioder(ya).stream())
             .collect(Collectors.toList());
-        return aktivitetsavtaler;
     }
 
     /**
@@ -281,10 +276,9 @@ public class YrkesaktivitetFilterDto {
      * @see #getAnsettelsesPerioder(YrkesaktivitetDto)
      */
     public Collection<AktivitetsAvtaleDto> getAnsettelsesPerioder() {
-        var ansettelsesPerioder = getYrkesaktiviteterInklusiveFiktive().stream() // NOSONAR: java:S1488
+        return getYrkesaktiviteterInklusiveFiktive().stream()
             .flatMap(ya -> getAnsettelsesPerioder(ya).stream())
             .collect(Collectors.toList());
-        return ansettelsesPerioder;
     }
 
 

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetFilterDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/iay/YrkesaktivitetFilterDto.java
@@ -85,10 +85,10 @@ public class YrkesaktivitetFilterDto {
 
     public Collection<YrkesaktivitetDto> getYrkesaktiviteter() {
         return getYrkesaktiviteterInklusiveFiktive().stream()
-                .filter(this::erIkkeFrilansOppdrag)
-                .filter(this::skalBrukes)
-                .filter(it -> (erArbeidsforholdOgStarterPåRettSideAvSkjæringstidspunkt(it) || !getAktivitetsAvtalerForArbeid(it).isEmpty()))
-                .collect(Collectors.toUnmodifiableSet());
+            .filter(this::erIkkeFrilansOppdrag)
+            .filter(this::skalBrukes)
+            .filter(it -> (erArbeidsforholdOgStarterPåRettSideAvSkjæringstidspunkt(it) || !getAktivitetsAvtalerForArbeid(it).isEmpty()))
+            .collect(Collectors.toUnmodifiableSet());
     }
 
     /**
@@ -133,8 +133,7 @@ public class YrkesaktivitetFilterDto {
     }
 
     private boolean erArbeidsforholdOgStarterPåRettSideAvSkjæringstidspunkt(YrkesaktivitetDto it) {
-        return it.erArbeidsforhold()
-                && getAnsettelsesPerioder(it).stream().anyMatch(ap -> skalMedEtterSkjæringstidspunktVurdering(ap));
+        return it.erArbeidsforhold() && getAnsettelsesPerioder(it).stream().anyMatch(ap -> skalMedEtterSkjæringstidspunktVurdering(ap));
     }
 
     private boolean erFrilansOppdrag(YrkesaktivitetDto aktivitet) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fastsettskjæringstidspunkt/AutopunktUtlederFastsettBeregningsaktiviteterMeldekortTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fastsettskjæringstidspunkt/AutopunktUtlederFastsettBeregningsaktiviteterMeldekortTjeneste.java
@@ -55,14 +55,12 @@ public class AutopunktUtlederFastsettBeregningsaktiviteterMeldekortTjeneste {
 
 
         if(BeregningstidspunktTjeneste.finnBeregningstidspunkt(skjæringstidspunkt).isBefore(skjæringstidspunkt) && opphørerYtelseDagenFørStp(nyligsteVedtak.get(), skjæringstidspunkt)){
-            var meldekortOpphørtYtelse = MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, // NOSONAR: java:S1488
+            return MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort,
                 nyligsteVedtak.get(), Set.of(nyligsteVedtak.get().getYtelseType()), skjæringstidspunkt.minusDays(1));
-            return meldekortOpphørtYtelse;
         }
 
-	    var meldekortLøpendeYtelse = MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, nyligsteVedtak.get(),  // NOSONAR: java:S1488
+	    return MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, nyligsteVedtak.get(),
                 Set.of(nyligsteVedtak.get().getYtelseType()), skjæringstidspunkt);
-        return meldekortLøpendeYtelse;
     }
 
     private static boolean harLøpendeVedtakOgSendtInnMeldekortNylig(Optional<AktørYtelseDto> aktørYtelse, LocalDate skjæringstidspunkt, Set<YtelseType> arenaytelseTyper) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fastsettskjæringstidspunkt/AutopunktUtlederFastsettBeregningsaktiviteterMeldekortTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fastsettskjæringstidspunkt/AutopunktUtlederFastsettBeregningsaktiviteterMeldekortTjeneste.java
@@ -55,12 +55,12 @@ public class AutopunktUtlederFastsettBeregningsaktiviteterMeldekortTjeneste {
 
 
         if(BeregningstidspunktTjeneste.finnBeregningstidspunkt(skjæringstidspunkt).isBefore(skjæringstidspunkt) && opphørerYtelseDagenFørStp(nyligsteVedtak.get(), skjæringstidspunkt)){
-            var meldekortOpphørtYtelse = MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, nyligsteVedtak.get(),
-                    Set.of(nyligsteVedtak.get().getYtelseType()), skjæringstidspunkt.minusDays(1));
+            var meldekortOpphørtYtelse = MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, // NOSONAR: java:S1488
+                nyligsteVedtak.get(), Set.of(nyligsteVedtak.get().getYtelseType()), skjæringstidspunkt.minusDays(1));
             return meldekortOpphørtYtelse;
         }
 
-	    var meldekortLøpendeYtelse = MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, nyligsteVedtak.get(),
+	    var meldekortLøpendeYtelse = MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, nyligsteVedtak.get(),  // NOSONAR: java:S1488
                 Set.of(nyligsteVedtak.get().getYtelseType()), skjæringstidspunkt);
         return meldekortLøpendeYtelse;
     }

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fastsettskjæringstidspunkt/AutopunktUtlederFastsettBeregningsaktiviteterMeldekortTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fastsettskjæringstidspunkt/AutopunktUtlederFastsettBeregningsaktiviteterMeldekortTjeneste.java
@@ -54,13 +54,14 @@ public class AutopunktUtlederFastsettBeregningsaktiviteterMeldekortTjeneste {
         var ytelseFilterMeldekort = new YtelseFilterDto(aktørYtelse);
 
 
-        if(BeregningstidspunktTjeneste.finnBeregningstidspunkt(skjæringstidspunkt).isBefore(skjæringstidspunkt) && opphørerYtelseDagenFørStp(nyligsteVedtak.get(), skjæringstidspunkt)){
-            return MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort,
-                nyligsteVedtak.get(), Set.of(nyligsteVedtak.get().getYtelseType()), skjæringstidspunkt.minusDays(1));
+        if (BeregningstidspunktTjeneste.finnBeregningstidspunkt(skjæringstidspunkt).isBefore(skjæringstidspunkt) && opphørerYtelseDagenFørStp(
+            nyligsteVedtak.get(), skjæringstidspunkt)) {
+            return MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, nyligsteVedtak.get(),
+                Set.of(nyligsteVedtak.get().getYtelseType()), skjæringstidspunkt.minusDays(1));
         }
 
-	    return MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, nyligsteVedtak.get(),
-                Set.of(nyligsteVedtak.get().getYtelseType()), skjæringstidspunkt);
+        return MeldekortUtils.finnesMeldekortSomInkludererGittDato(ytelseFilterMeldekort, nyligsteVedtak.get(),
+            Set.of(nyligsteVedtak.get().getYtelseType()), skjæringstidspunkt);
     }
 
     private static boolean harLøpendeVedtakOgSendtInnMeldekortNylig(Optional<AktørYtelseDto> aktørYtelse, LocalDate skjæringstidspunkt, Set<YtelseType> arenaytelseTyper) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeForLønnsendring.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeForLønnsendring.java
@@ -96,7 +96,7 @@ public class FastsettBeregningsperiodeForLønnsendring {
 
 
     public static Map<BeregningsgrunnlagPrStatusOgAndelDto, List<YrkesaktivitetDto>> finnAndelAktivitetMap(List<YrkesaktivitetDto> yrkesaktiviteterMedLønnsendring, BeregningsgrunnlagPeriodeDto periode) {
-        var andelLønnsendringMap = periode.getBeregningsgrunnlagPrStatusOgAndelList().stream()
+        var andelLønnsendringMap = periode.getBeregningsgrunnlagPrStatusOgAndelList().stream()  // NOSONAR: java:S1488
                 .filter(a -> harLønnsendring(yrkesaktiviteterMedLønnsendring, a))
                 .collect(Collectors.toMap(a -> a, a -> finnMatchendeYrkesaktiviteterMedLønnsendring(yrkesaktiviteterMedLønnsendring, a)));
         return andelLønnsendringMap;

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeForLønnsendring.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeForLønnsendring.java
@@ -96,10 +96,9 @@ public class FastsettBeregningsperiodeForLønnsendring {
 
 
     public static Map<BeregningsgrunnlagPrStatusOgAndelDto, List<YrkesaktivitetDto>> finnAndelAktivitetMap(List<YrkesaktivitetDto> yrkesaktiviteterMedLønnsendring, BeregningsgrunnlagPeriodeDto periode) {
-        var andelLønnsendringMap = periode.getBeregningsgrunnlagPrStatusOgAndelList().stream()  // NOSONAR: java:S1488
+        return periode.getBeregningsgrunnlagPrStatusOgAndelList().stream()
                 .filter(a -> harLønnsendring(yrkesaktiviteterMedLønnsendring, a))
                 .collect(Collectors.toMap(a -> a, a -> finnMatchendeYrkesaktiviteterMedLønnsendring(yrkesaktiviteterMedLønnsendring, a)));
-        return andelLønnsendringMap;
     }
 
     public static LocalDate finnSisteLønnsendringIBeregningsperioden(List<YrkesaktivitetDto> yrkesaktiviteter, Intervall beregningsperiode) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeForLønnsendring.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeForLønnsendring.java
@@ -96,9 +96,10 @@ public class FastsettBeregningsperiodeForLønnsendring {
 
 
     public static Map<BeregningsgrunnlagPrStatusOgAndelDto, List<YrkesaktivitetDto>> finnAndelAktivitetMap(List<YrkesaktivitetDto> yrkesaktiviteterMedLønnsendring, BeregningsgrunnlagPeriodeDto periode) {
-        return periode.getBeregningsgrunnlagPrStatusOgAndelList().stream()
-                .filter(a -> harLønnsendring(yrkesaktiviteterMedLønnsendring, a))
-                .collect(Collectors.toMap(a -> a, a -> finnMatchendeYrkesaktiviteterMedLønnsendring(yrkesaktiviteterMedLønnsendring, a)));
+        return periode.getBeregningsgrunnlagPrStatusOgAndelList()
+            .stream()
+            .filter(a -> harLønnsendring(yrkesaktiviteterMedLønnsendring, a))
+            .collect(Collectors.toMap(a -> a, a -> finnMatchendeYrkesaktiviteterMedLønnsendring(yrkesaktiviteterMedLønnsendring, a)));
     }
 
     public static LocalDate finnSisteLønnsendringIBeregningsperioden(List<YrkesaktivitetDto> yrkesaktiviteter, Intervall beregningsperiode) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeTjeneste.java
@@ -23,7 +23,8 @@ public class FastsettBeregningsperiodeTjeneste {
         var fastsattForATFL = fastsettBeregningsperiodeForATFL(beregningsgrunnlag, new BeregningsperiodeTjeneste().fastsettBeregningsperiodeForATFLAndeler(beregningsgrunnlag.getSkjæringstidspunkt()));
         // Fastsetter for arbeidsforhold med lønnsendring innenfor siste 3 måneder før skjæringstidspunktet
         if (KonfigurasjonVerdi.instance().get("AUTOMATISK_BEREGNE_LONNSENDRING", false) || KonfigurasjonVerdi.instance().get("AUTOMATISK_BEREGNE_LONNSENDRING_V2", false)) {
-            var fastsattForLønnsendring = fastsettBeregningsperiodeForLønnsendring(fastsattForATFL, inntektArbeidYtelseGrunnlag, inntektsmeldinger);
+            var fastsattForLønnsendring = fastsettBeregningsperiodeForLønnsendring(fastsattForATFL, // NOSONAR: java:S1488
+                inntektArbeidYtelseGrunnlag, inntektsmeldinger);
             return fastsattForLønnsendring;
 
         } else {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeTjeneste.java
@@ -23,9 +23,8 @@ public class FastsettBeregningsperiodeTjeneste {
         var fastsattForATFL = fastsettBeregningsperiodeForATFL(beregningsgrunnlag, new BeregningsperiodeTjeneste().fastsettBeregningsperiodeForATFLAndeler(beregningsgrunnlag.getSkjæringstidspunkt()));
         // Fastsetter for arbeidsforhold med lønnsendring innenfor siste 3 måneder før skjæringstidspunktet
         if (KonfigurasjonVerdi.instance().get("AUTOMATISK_BEREGNE_LONNSENDRING", false) || KonfigurasjonVerdi.instance().get("AUTOMATISK_BEREGNE_LONNSENDRING_V2", false)) {
-            var fastsattForLønnsendring = fastsettBeregningsperiodeForLønnsendring(fastsattForATFL, // NOSONAR: java:S1488
+            return fastsettBeregningsperiodeForLønnsendring(fastsattForATFL,
                 inntektArbeidYtelseGrunnlag, inntektsmeldinger);
-            return fastsattForLønnsendring;
 
         } else {
             return fastsattForATFL;

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/skjæringstidspunkt/FastsettBeregningsperiodeTjeneste.java
@@ -23,13 +23,9 @@ public class FastsettBeregningsperiodeTjeneste {
         var fastsattForATFL = fastsettBeregningsperiodeForATFL(beregningsgrunnlag, new BeregningsperiodeTjeneste().fastsettBeregningsperiodeForATFLAndeler(beregningsgrunnlag.getSkjæringstidspunkt()));
         // Fastsetter for arbeidsforhold med lønnsendring innenfor siste 3 måneder før skjæringstidspunktet
         if (KonfigurasjonVerdi.instance().get("AUTOMATISK_BEREGNE_LONNSENDRING", false) || KonfigurasjonVerdi.instance().get("AUTOMATISK_BEREGNE_LONNSENDRING_V2", false)) {
-            return fastsettBeregningsperiodeForLønnsendring(fastsattForATFL,
-                inntektArbeidYtelseGrunnlag, inntektsmeldinger);
-
+            return fastsettBeregningsperiodeForLønnsendring(fastsattForATFL, inntektArbeidYtelseGrunnlag, inntektsmeldinger);
         } else {
             return fastsattForATFL;
         }
     }
-
-
 }

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/tid/Intervall.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/tid/Intervall.java
@@ -59,8 +59,7 @@ public class Intervall implements Comparable<Intervall> {
     public boolean overlapper(Intervall other) {
         var fomBeforeOrEqual = this.getFomDato().isBefore(other.getTomDato()) || this.getFomDato().isEqual(other.getTomDato());
         var tomAfterOrEqual = this.getTomDato().isAfter(other.getFomDato()) || this.getTomDato().isEqual(other.getFomDato());
-        var overlapper = fomBeforeOrEqual && tomAfterOrEqual;  // NOSONAR: java:S1488
-        return overlapper;
+        return fomBeforeOrEqual && tomAfterOrEqual;
     }
 
     public boolean inkluderer(Intervall other) {

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/tid/Intervall.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/tid/Intervall.java
@@ -59,7 +59,7 @@ public class Intervall implements Comparable<Intervall> {
     public boolean overlapper(Intervall other) {
         var fomBeforeOrEqual = this.getFomDato().isBefore(other.getTomDato()) || this.getFomDato().isEqual(other.getTomDato());
         var tomAfterOrEqual = this.getTomDato().isAfter(other.getFomDato()) || this.getTomDato().isEqual(other.getFomDato());
-        var overlapper = fomBeforeOrEqual && tomAfterOrEqual;
+        var overlapper = fomBeforeOrEqual && tomAfterOrEqual;  // NOSONAR: java:S1488
         return overlapper;
     }
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/adapter/RegelMapperTestDataHelper.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/adapter/RegelMapperTestDataHelper.java
@@ -150,19 +150,17 @@ public class RegelMapperTestDataHelper {
 
     public static BeregningsgrunnlagPrStatus buildRegelBGPeriode(no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.resultat.BeregningsgrunnlagPeriode regelBGP, no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.AktivitetStatus status, Periode periode) {
         if (no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.AktivitetStatus.erArbeidstakerEllerFrilanser(status)) {
-            final var regelBGPStatus = BeregningsgrunnlagPrStatus.builder(regelBGP.getBeregningsgrunnlagPrStatus(status))
+            return BeregningsgrunnlagPrStatus.builder(regelBGP.getBeregningsgrunnlagPrStatus(status))
                 .medBeregningsperiode(periode)
                 .build();
-            return regelBGPStatus;
         } else {
-            final var regelBGPStatus = BeregningsgrunnlagPrStatus.builder(regelBGP.getBeregningsgrunnlagPrStatus(status))
+            return BeregningsgrunnlagPrStatus.builder(regelBGP.getBeregningsgrunnlagPrStatus(status))
                 .medFordeltPrÅr(BigDecimal.valueOf(400000.42))
                 .medBeregnetPrÅr(BigDecimal.valueOf(400000.42))
                 .medAvkortetPrÅr(BigDecimal.valueOf(789.789))
                 .medRedusertPrÅr(BigDecimal.valueOf(901.901))
                 .medBeregningsperiode(periode)
                 .build();
-            return regelBGPStatus;
         }
     }
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/adapter/regelmodelltilvl/MapFastsettBeregningsgrunnlagPerioderFraRegelTilVLTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/adapter/regelmodelltilvl/MapFastsettBeregningsgrunnlagPerioderFraRegelTilVLTest.java
@@ -85,14 +85,13 @@ class MapFastsettBeregningsgrunnlagPerioderFraRegelTilVLTest {
 
 
     private BeregningsgrunnlagDto lagBeregningsgrunnlag() {
-        var vlBeregningsgrunnlag = BeregningsgrunnlagDto.builder()  // NOSONAR: java:S1488
+        return BeregningsgrunnlagDto.builder()
             .medSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT)
             .medOverstyring(true)
             .medGrunnbeløp(GRUNNBELØP)
             .leggTilFaktaOmBeregningTilfeller(FAKTA_OM_BEREGNING_TILFELLER)
             .leggTilSammenligningsgrunnlag(lagSammenligningsgrunnlagPrStatus())
             .build();
-        return vlBeregningsgrunnlag;
     }
 
     private BeregningsgrunnlagPrStatusOgAndelDto lagBeregnignsgrunnlagPrStatusOgAndel(BeregningsgrunnlagPeriodeDto periode) {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/adapter/regelmodelltilvl/MapFastsettBeregningsgrunnlagPerioderFraRegelTilVLTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/adapter/regelmodelltilvl/MapFastsettBeregningsgrunnlagPerioderFraRegelTilVLTest.java
@@ -85,7 +85,7 @@ class MapFastsettBeregningsgrunnlagPerioderFraRegelTilVLTest {
 
 
     private BeregningsgrunnlagDto lagBeregningsgrunnlag() {
-        var vlBeregningsgrunnlag = BeregningsgrunnlagDto.builder()
+        var vlBeregningsgrunnlag = BeregningsgrunnlagDto.builder()  // NOSONAR: java:S1488
             .medSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT)
             .medOverstyring(true)
             .medGrunnbeløp(GRUNNBELØP)

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/UtledStartdatoTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/adapter/vltilregelmodell/UtledStartdatoTest.java
@@ -92,9 +92,9 @@ class UtledStartdatoTest {
     private static InntektArbeidYtelseGrunnlagDto lagIay(List<YrkesaktivitetDto> yrkesaktiviteter) {
         var aktørArbeidBuilder = InntektArbeidYtelseAggregatBuilder.AktørArbeidBuilder.oppdatere(Optional.empty());
         yrkesaktiviteter.forEach(aktørArbeidBuilder::leggTilYrkesaktivitet);
-        var iayGrunnlag = InntektArbeidYtelseGrunnlagDtoBuilder.nytt()
-                .medData(InntektArbeidYtelseAggregatBuilder.oppdatere(Optional.empty(), VersjonTypeDto.REGISTER).leggTilAktørArbeid(aktørArbeidBuilder)).build();
-        return iayGrunnlag;
+        return InntektArbeidYtelseGrunnlagDtoBuilder.nytt()
+            .medData(InntektArbeidYtelseAggregatBuilder.oppdatere(Optional.empty(), VersjonTypeDto.REGISTER).leggTilAktørArbeid(aktørArbeidBuilder))
+            .build();
     }
 
     private static YrkesaktivitetDto byggYrkesaktivitet(List<Intervall> ansettelsesperioder, InternArbeidsforholdRefDto ref, Arbeidsgiver arbeidsgiver) {
@@ -102,8 +102,7 @@ class UtledStartdatoTest {
                 .medArbeidsforholdId(ref)
                 .medArbeidsgiver(arbeidsgiver);
         ansettelsesperioder.forEach(p -> leggTilAnsettelsesperiode(yrkesaktivitetBuilder, p));
-        var yrkesaktivitet = yrkesaktivitetBuilder.build();
-        return yrkesaktivitet;
+        return yrkesaktivitetBuilder.build();
     }
 
     private static void leggTilAnsettelsesperiode(YrkesaktivitetDtoBuilder yrkesaktivitetBuilder, Intervall p) {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/BeregningsgrunnlagPrStatusOgAndelDtoTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/BeregningsgrunnlagPrStatusOgAndelDtoTjenesteTest.java
@@ -286,11 +286,9 @@ class BeregningsgrunnlagPrStatusOgAndelDtoTjenesteTest {
     }
 
     private BeregningsgrunnlagDto lagBeregningsgrunnlagUtenSammenligningsgrunnlag() {
-        var beregningsgrunnlag = BeregningsgrunnlagDto.builder()  // NOSONAR: java:S1488
+        return BeregningsgrunnlagDto.builder()
                 .medSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT)
                 .build();
-
-        return beregningsgrunnlag;
     }
 
     private BeregningsgrunnlagDto lagBeregningsgrunnlagMedAvvikUnder25ProsentMedKunSammenligningsgrunnlag() {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/BeregningsgrunnlagPrStatusOgAndelDtoTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/BeregningsgrunnlagPrStatusOgAndelDtoTjenesteTest.java
@@ -286,9 +286,7 @@ class BeregningsgrunnlagPrStatusOgAndelDtoTjenesteTest {
     }
 
     private BeregningsgrunnlagDto lagBeregningsgrunnlagUtenSammenligningsgrunnlag() {
-        return BeregningsgrunnlagDto.builder()
-                .medSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT)
-                .build();
+        return BeregningsgrunnlagDto.builder() .medSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT) .build();
     }
 
     private BeregningsgrunnlagDto lagBeregningsgrunnlagMedAvvikUnder25ProsentMedKunSammenligningsgrunnlag() {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/BeregningsgrunnlagPrStatusOgAndelDtoTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/BeregningsgrunnlagPrStatusOgAndelDtoTjenesteTest.java
@@ -286,7 +286,7 @@ class BeregningsgrunnlagPrStatusOgAndelDtoTjenesteTest {
     }
 
     private BeregningsgrunnlagDto lagBeregningsgrunnlagUtenSammenligningsgrunnlag() {
-        var beregningsgrunnlag = BeregningsgrunnlagDto.builder()
+        var beregningsgrunnlag = BeregningsgrunnlagDto.builder()  // NOSONAR: java:S1488
                 .medSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT)
                 .build();
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/FinnInntektFraYtelseTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/FinnInntektFraYtelseTest.java
@@ -106,14 +106,13 @@ class FinnInntektFraYtelseTest {
             .leggTilBeregningsgrunnlagPrStatusOgAndel(andel1)
             .build(bg);
 
-        var andel2 = BeregningsgrunnlagPrStatusOgAndelDto.Builder.ny()  // NOSONAR: java:S1488
+        return BeregningsgrunnlagPrStatusOgAndelDto.Builder.ny()
             .medAktivitetStatus(AktivitetStatus.DAGPENGER)
             .medBeregnetPrÅr(Beløp.fra(5000))
             .medBGAndelArbeidsforhold(BGAndelArbeidsforholdDto.builder().medArbeidsgiver(Arbeidsgiver.virksomhet("1234534")))
             .medAndelsnr(1L)
             .medBeregningsperiode(fom, tom)
             .build(periode);
-        return andel2;
     }
 
     private YtelseDtoBuilder lagYtelse(YtelseType ytelsetype, LocalDate fom, LocalDate tom, YtelseKilde ytelseKilde) {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/FinnInntektFraYtelseTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/FinnInntektFraYtelseTest.java
@@ -106,7 +106,7 @@ class FinnInntektFraYtelseTest {
             .leggTilBeregningsgrunnlagPrStatusOgAndel(andel1)
             .build(bg);
 
-        var andel2 = BeregningsgrunnlagPrStatusOgAndelDto.Builder.ny()
+        var andel2 = BeregningsgrunnlagPrStatusOgAndelDto.Builder.ny()  // NOSONAR: java:S1488
             .medAktivitetStatus(AktivitetStatus.DAGPENGER)
             .medBeregnetPrÅr(Beløp.fra(5000))
             .medBGAndelArbeidsforhold(BGAndelArbeidsforholdDto.builder().medArbeidsgiver(Arbeidsgiver.virksomhet("1234534")))

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/VurderLønnsendringDtoTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/VurderLønnsendringDtoTjenesteTest.java
@@ -99,9 +99,8 @@ class VurderLønnsendringDtoTjenesteTest {
         var yrkesaktivitetBuilder = lagYrkesaktivitetMedLønnsendring(sisteLønnsendringsdato);
         aktørArbeidBuilder.leggTilYrkesaktivitet(yrkesaktivitetBuilder);
         dataBuilder.leggTilAktørArbeid(aktørArbeidBuilder);
-        var iayGrunnlag = InntektArbeidYtelseGrunnlagDtoBuilder.nytt()
+        return InntektArbeidYtelseGrunnlagDtoBuilder.nytt()
                 .medData(dataBuilder).build();
-        return iayGrunnlag;
     }
 
     private YrkesaktivitetDtoBuilder lagYrkesaktivitetMedLønnsendring(LocalDate sisteLønnsendringsdato) {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/AvklaringsbehovUtlederFordelBeregningTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/AvklaringsbehovUtlederFordelBeregningTest.java
@@ -61,8 +61,8 @@ class AvklaringsbehovUtlederFordelBeregningTest {
 
     private List<BeregningAvklaringsbehovResultat> utledAvklaringsbehov(KoblingReferanse ref, BeregningsgrunnlagGrunnlagDto grunnlag) {
 	    var foreldrepengerGrunnlag = new ForeldrepengerGrunnlag(Dekningsgrad.DEKNINGSGRAD_100, false);
-        return AvklaringsbehovUtlederFordelBeregning.utledAvklaringsbehovFor(ref, grunnlag,
-            foreldrepengerGrunnlag, InntektArbeidYtelseGrunnlagDtoBuilder.nytt().build(), Collections.emptyList());
+        return AvklaringsbehovUtlederFordelBeregning.utledAvklaringsbehovFor(ref, grunnlag, foreldrepengerGrunnlag,
+            InntektArbeidYtelseGrunnlagDtoBuilder.nytt().build(), Collections.emptyList());
     }
 
     @Test

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/AvklaringsbehovUtlederFordelBeregningTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/AvklaringsbehovUtlederFordelBeregningTest.java
@@ -61,7 +61,8 @@ class AvklaringsbehovUtlederFordelBeregningTest {
 
     private List<BeregningAvklaringsbehovResultat> utledAvklaringsbehov(KoblingReferanse ref, BeregningsgrunnlagGrunnlagDto grunnlag) {
 	    var foreldrepengerGrunnlag = new ForeldrepengerGrunnlag(Dekningsgrad.DEKNINGSGRAD_100, false);
-	    var avklaringsbehovResultats = AvklaringsbehovUtlederFordelBeregning.utledAvklaringsbehovFor(ref, grunnlag, foreldrepengerGrunnlag, InntektArbeidYtelseGrunnlagDtoBuilder.nytt().build(), Collections.emptyList());
+        var avklaringsbehovResultats = AvklaringsbehovUtlederFordelBeregning.utledAvklaringsbehovFor(ref, grunnlag, // NOSONAR: java:S1488
+            foreldrepengerGrunnlag, InntektArbeidYtelseGrunnlagDtoBuilder.nytt().build(), Collections.emptyList());
         return avklaringsbehovResultats;
     }
 
@@ -111,7 +112,7 @@ class AvklaringsbehovUtlederFordelBeregningTest {
             andel.medFordeltPrÅr(Beløp.fra(100_000));
         }
         andel.build(periode);
-        var grunnlag = BeregningsgrunnlagGrunnlagDtoBuilder.oppdatere(Optional.empty())
+        var grunnlag = BeregningsgrunnlagGrunnlagDtoBuilder.oppdatere(Optional.empty()) // NOSONAR: java:S1488
             .medBeregningsgrunnlag(beregningsgrunnlag)
             .medRegisterAktiviteter(beregningAktivitetBuilder.build())
             .build(BeregningsgrunnlagTilstand.OPPDATERT_MED_ANDELER);
@@ -139,7 +140,7 @@ class AvklaringsbehovUtlederFordelBeregningTest {
             .medArbeidsforholdRef(InternArbeidsforholdRefDto.nullRef())
             .build());
 
-        var grunnlag = BeregningsgrunnlagGrunnlagDtoBuilder.oppdatere(Optional.empty())
+        var grunnlag = BeregningsgrunnlagGrunnlagDtoBuilder.oppdatere(Optional.empty()) // NOSONAR: java:S1488
             .medBeregningsgrunnlag(beregningsgrunnlag)
             .medRegisterAktiviteter(beregningAktivitetBuilder.build())
             .build(BeregningsgrunnlagTilstand.OPPDATERT_MED_ANDELER);

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/AvklaringsbehovUtlederFordelBeregningTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/AvklaringsbehovUtlederFordelBeregningTest.java
@@ -61,9 +61,8 @@ class AvklaringsbehovUtlederFordelBeregningTest {
 
     private List<BeregningAvklaringsbehovResultat> utledAvklaringsbehov(KoblingReferanse ref, BeregningsgrunnlagGrunnlagDto grunnlag) {
 	    var foreldrepengerGrunnlag = new ForeldrepengerGrunnlag(Dekningsgrad.DEKNINGSGRAD_100, false);
-        var avklaringsbehovResultats = AvklaringsbehovUtlederFordelBeregning.utledAvklaringsbehovFor(ref, grunnlag, // NOSONAR: java:S1488
+        return AvklaringsbehovUtlederFordelBeregning.utledAvklaringsbehovFor(ref, grunnlag,
             foreldrepengerGrunnlag, InntektArbeidYtelseGrunnlagDtoBuilder.nytt().build(), Collections.emptyList());
-        return avklaringsbehovResultats;
     }
 
     @Test
@@ -112,11 +111,10 @@ class AvklaringsbehovUtlederFordelBeregningTest {
             andel.medFordeltPrÅr(Beløp.fra(100_000));
         }
         andel.build(periode);
-        var grunnlag = BeregningsgrunnlagGrunnlagDtoBuilder.oppdatere(Optional.empty()) // NOSONAR: java:S1488
+        return BeregningsgrunnlagGrunnlagDtoBuilder.oppdatere(Optional.empty())
             .medBeregningsgrunnlag(beregningsgrunnlag)
             .medRegisterAktiviteter(beregningAktivitetBuilder.build())
             .build(BeregningsgrunnlagTilstand.OPPDATERT_MED_ANDELER);
-        return grunnlag;
     }
 
     private BeregningsgrunnlagGrunnlagDto lagGrunnlagutenNyttArbeidsforhold(FaktaOmBeregningTilfelle... tilfeller) {
@@ -140,11 +138,10 @@ class AvklaringsbehovUtlederFordelBeregningTest {
             .medArbeidsforholdRef(InternArbeidsforholdRefDto.nullRef())
             .build());
 
-        var grunnlag = BeregningsgrunnlagGrunnlagDtoBuilder.oppdatere(Optional.empty()) // NOSONAR: java:S1488
+        return BeregningsgrunnlagGrunnlagDtoBuilder.oppdatere(Optional.empty())
             .medBeregningsgrunnlag(beregningsgrunnlag)
             .medRegisterAktiviteter(beregningAktivitetBuilder.build())
             .build(BeregningsgrunnlagTilstand.OPPDATERT_MED_ANDELER);
-        return grunnlag;
     }
 
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
@@ -628,8 +628,7 @@ class AvklaringsbehovUtlederTilkommetInntektTest {
 			oppdatere.leggTilAktørYtelse(aktørYtelse);
 
 		}
-		var iay = InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(oppdatere).build();  // NOSONAR: java:S1488
-		return iay;
+		return InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(oppdatere).build();
 	}
 
 	private List<InntektDtoBuilder> lagInntektForYrkesaktiviteter(List<YrkesaktivitetDto> yrkesaktiviteter, PleiepengerSyktBarnGrunnlag utbetalingsgradGrunnlag) {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederTilkommetInntektTest.java
@@ -628,7 +628,7 @@ class AvklaringsbehovUtlederTilkommetInntektTest {
 			oppdatere.leggTilAktørYtelse(aktørYtelse);
 
 		}
-		var iay = InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(oppdatere).build();
+		var iay = InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(oppdatere).build();  // NOSONAR: java:S1488
 		return iay;
 	}
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/kontrollerfakta/VurderMottarYtelseTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/kontrollerfakta/VurderMottarYtelseTjenesteTest.java
@@ -274,20 +274,18 @@ class VurderMottarYtelseTjenesteTest {
         var register = InntektArbeidYtelseAggregatBuilder.oppdatere(Optional.empty(), VersjonTypeDto.REGISTER);
         register.leggTilAktørInntekt(lagAktørInntektMedYtelse()).build();
         register.leggTilAktørYtelse(lagAktørYtelseForFrilans());
-        var inntektArbeidYtelseGrunnlagDto = InntektArbeidYtelseGrunnlagDtoBuilder.nytt()
+        return InntektArbeidYtelseGrunnlagDtoBuilder.nytt()
                 .medData(register)
                 .build();
-        return inntektArbeidYtelseGrunnlagDto;
     }
 
     private InntektArbeidYtelseGrunnlagDto lagIAYMedYtelse(Arbeidsgiver arbeidsgiver, boolean fullRefusjon) {
         var register = InntektArbeidYtelseAggregatBuilder.oppdatere(Optional.empty(), VersjonTypeDto.REGISTER);
         register.leggTilAktørInntekt(lagAktørInntektMedYtelse()).build();
         register.leggTilAktørYtelse(lagAktørYtelseForArbeidsgiver(arbeidsgiver, fullRefusjon));
-        var inntektArbeidYtelseGrunnlagDto = InntektArbeidYtelseGrunnlagDtoBuilder.nytt()
+        return InntektArbeidYtelseGrunnlagDtoBuilder.nytt()
                 .medData(register)
                 .build();
-        return inntektArbeidYtelseGrunnlagDto;
     }
 
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/kontrollerfakta/inntektskategori/FastsettInntektskategoriTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/kontrollerfakta/inntektskategori/FastsettInntektskategoriTjenesteTest.java
@@ -90,8 +90,7 @@ class FastsettInntektskategoriTjenesteTest {
     private InntektArbeidYtelseGrunnlagDto lagIAY(InntektDtoBuilder inntektBuilder) {
         var aktørInntektBuilder = InntektArbeidYtelseAggregatBuilder.AktørInntektBuilder.oppdatere(Optional.empty()).leggTilInntekt(inntektBuilder);
         var data = InntektArbeidYtelseAggregatBuilder.oppdatere(Optional.empty(), VersjonTypeDto.REGISTER).leggTilAktørInntekt(aktørInntektBuilder);
-        var iay = InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(data).build();  // NOSONAR: java:S1488
-        return iay;
+        return InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(data).build();
     }
 
     @Test

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/kontrollerfakta/inntektskategori/FastsettInntektskategoriTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/kontrollerfakta/inntektskategori/FastsettInntektskategoriTjenesteTest.java
@@ -90,7 +90,7 @@ class FastsettInntektskategoriTjenesteTest {
     private InntektArbeidYtelseGrunnlagDto lagIAY(InntektDtoBuilder inntektBuilder) {
         var aktørInntektBuilder = InntektArbeidYtelseAggregatBuilder.AktørInntektBuilder.oppdatere(Optional.empty()).leggTilInntekt(inntektBuilder);
         var data = InntektArbeidYtelseAggregatBuilder.oppdatere(Optional.empty(), VersjonTypeDto.REGISTER).leggTilAktørInntekt(aktørInntektBuilder);
-        var iay = InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(data).build();
+        var iay = InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(data).build();  // NOSONAR: java:S1488
         return iay;
     }
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektsforholdTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/tilkommetInntekt/TilkommetInntektsforholdTjenesteTest.java
@@ -133,8 +133,7 @@ class TilkommetInntektsforholdTjenesteTest {
 		var aktørArbeid = InntektArbeidYtelseAggregatBuilder.AktørArbeidBuilder.oppdatere(Optional.empty());
 		yrkesaktiviteter.forEach(aktørArbeid::leggTilYrkesaktivitet);
 		oppdatere.leggTilAktørArbeid(aktørArbeid);
-		var iay = InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(oppdatere).build();
-		return iay;
+        return InntektArbeidYtelseGrunnlagDtoBuilder.nytt().medData(oppdatere).build();
 	}
 
 	private BeregningsgrunnlagPrStatusOgAndelDto lagArbeidstakerandel(Arbeidsgiver arbeidsgiver2, long andelsnr, AndelKilde kilde, InternArbeidsforholdRefDto arbeidsforholdRef) {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/testutilities/behandling/beregningsgrunnlag/BeregningAktivitetTestUtil.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/testutilities/behandling/beregningsgrunnlag/BeregningAktivitetTestUtil.java
@@ -24,8 +24,7 @@ public class BeregningAktivitetTestUtil {
                 .build();
             builder.leggTilAktivitet(beregningAktivitet);
         }
-	    var aggregat = builder.build();  // NOSONAR: java:S1488
-        return aggregat;
+	    return builder.build();
     }
 
 }

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/testutilities/behandling/beregningsgrunnlag/BeregningAktivitetTestUtil.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/testutilities/behandling/beregningsgrunnlag/BeregningAktivitetTestUtil.java
@@ -24,7 +24,7 @@ public class BeregningAktivitetTestUtil {
                 .build();
             builder.leggTilAktivitet(beregningAktivitet);
         }
-	    var aggregat = builder.build();
+	    var aggregat = builder.build();  // NOSONAR: java:S1488
         return aggregat;
     }
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/FullføreBeregningsgrunnlagUtbgradTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/FullføreBeregningsgrunnlagUtbgradTest.java
@@ -1137,10 +1137,9 @@ class FullføreBeregningsgrunnlagUtbgradTest {
     }
 
     private SvangerskapspengerGrunnlag lagSvangerskapspengerGrunnlag(List<UtbetalingsgradPrAktivitetDto> tilretteleggingMedUtbelingsgrad) {
-        var svangerskapspengerGrunnlag = new SvangerskapspengerGrunnlag(  // NOSONAR: java:S1488
+        return new SvangerskapspengerGrunnlag(
                 tilretteleggingMedUtbelingsgrad
         );
-        return svangerskapspengerGrunnlag;
     }
 
 }

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/FullføreBeregningsgrunnlagUtbgradTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/FullføreBeregningsgrunnlagUtbgradTest.java
@@ -1137,9 +1137,6 @@ class FullføreBeregningsgrunnlagUtbgradTest {
     }
 
     private SvangerskapspengerGrunnlag lagSvangerskapspengerGrunnlag(List<UtbetalingsgradPrAktivitetDto> tilretteleggingMedUtbelingsgrad) {
-        return new SvangerskapspengerGrunnlag(
-                tilretteleggingMedUtbelingsgrad
-        );
+        return new SvangerskapspengerGrunnlag(tilretteleggingMedUtbelingsgrad);
     }
-
 }

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/FullføreBeregningsgrunnlagUtbgradTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/ytelse/utbgradytelse/FullføreBeregningsgrunnlagUtbgradTest.java
@@ -1137,7 +1137,7 @@ class FullføreBeregningsgrunnlagUtbgradTest {
     }
 
     private SvangerskapspengerGrunnlag lagSvangerskapspengerGrunnlag(List<UtbetalingsgradPrAktivitetDto> tilretteleggingMedUtbelingsgrad) {
-        var svangerskapspengerGrunnlag = new SvangerskapspengerGrunnlag(
+        var svangerskapspengerGrunnlag = new SvangerskapspengerGrunnlag(  // NOSONAR: java:S1488
                 tilretteleggingMedUtbelingsgrad
         );
         return svangerskapspengerGrunnlag;


### PR DESCRIPTION
* Fikser sonar-feilen S1488: Returner i stedet for å assigne til variabel