### PR TITLE
TFP-6598: Bruker nye feltet orginalDagsatsFraTilstøtendeYtelse

### DIFF
--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/regelmodell/grunnlag/inntekt/Inntektsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/regelmodell/grunnlag/inntekt/Inntektsgrunnlag.java
@@ -105,12 +105,6 @@ public class Inntektsgrunnlag {
 				.max(Comparator.comparing(Periodeinntekt::getFom));
 	}
 
-    public Optional<Periodeinntekt> getSistePeriodeinntektMedTypeIPeriode(Inntektskilde kilde, Periode periode) {
-        return getSistePeriodeinntektMedType(kilde).stream()
-            .filter(pi -> periode.getFom().isBefore(pi.getTom()) && periode.getTom().isAfter(pi.getTom()))
-            .findFirst();
-    }
-
 	public List<Periodeinntekt> getSistePeriodeinntekterMedType(Inntektskilde kilde) {
 		var inntekter = getPeriodeinntektMedKilde(kilde).toList();
 		var sisteTomDato = inntekter.stream()

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/regelmodell/grunnlag/inntekt/Inntektsgrunnlag.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/regelmodell/grunnlag/inntekt/Inntektsgrunnlag.java
@@ -85,7 +85,6 @@ public class Inntektsgrunnlag {
 		}
 	}
 
-
 	public Optional<LocalDate> sistePeriodeMedInntektFørDato(Inntektskilde inntektskilde, LocalDate dato) {
         var perioder = getPeriodeinntektMedKilde(inntektskilde)
 				.filter(pi -> dato.isAfter(pi.getTom()))
@@ -101,11 +100,16 @@ public class Inntektsgrunnlag {
         return getPeriodeinntektMedKilde(kilde).anyMatch(i -> i.getPeriode().inneholder(dato));
     }
 
-
     public Optional<Periodeinntekt> getSistePeriodeinntektMedType(Inntektskilde kilde) {
 		return getPeriodeinntektMedKilde(kilde)
 				.max(Comparator.comparing(Periodeinntekt::getFom));
 	}
+
+    public Optional<Periodeinntekt> getSistePeriodeinntektMedTypeIPeriode(Inntektskilde kilde, Periode periode) {
+        return getSistePeriodeinntektMedType(kilde).stream()
+            .filter(pi -> periode.getFom().isBefore(pi.getTom()) && periode.getTom().isAfter(pi.getTom()))
+            .findFirst();
+    }
 
 	public List<Periodeinntekt> getSistePeriodeinntekterMedType(Inntektskilde kilde) {
 		var inntekter = getPeriodeinntektMedKilde(kilde).toList();

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/FastsettAAPManuelt.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/FastsettAAPManuelt.java
@@ -2,11 +2,10 @@ package no.nav.folketrygdloven.beregningsgrunnlag.ytelse.dagpengerelleraap;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.AktivitetStatus;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.BeregningsgrunnlagHjemmel;
-import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.Periode;
-import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.grunnlag.inntekt.Inntektskilde;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.resultat.BeregningsgrunnlagPeriode;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.resultat.BeregningsgrunnlagPrStatus;
 import no.nav.fpsak.nare.doc.RuleDocumentation;
@@ -30,13 +29,10 @@ class FastsettAAPManuelt extends LeafSpecification<BeregningsgrunnlagPeriode> {
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("Ingen aktivitetstatus av type DP eller AAP funnet."));
 
-        var aktuellInntektsperiode = Periode.of(grunnlag.getSkjæringstidspunkt().minusDays(8), grunnlag.getSkjæringstidspunkt().plusDays(1));
-        var inntekt = grunnlag.getInntektsgrunnlag()
-            .getSistePeriodeinntektMedTypeIPeriode(Inntektskilde.TILSTØTENDE_YTELSE_DP_AAP, aktuellInntektsperiode)
-            .orElseThrow(() -> new IllegalStateException("Ingen inntekter fra tilstøtende ytelser funnet i siste uke med inntekt"));
-
+        var originalDagsats = Objects.requireNonNull(grunnlag.getInntektsgrunnlag().getDagsatsYtelseDpAapVedSkjæringstidspunkt(),
+            "Ingen dagsats funnet for AAP ved skjæringstidspunkt").longValue();
         var beregnetPrÅr = bgPerStatus.getBeregnetPrÅr();
-        Long originalDagsats = inntekt.getInntekt().longValue();
+
         BeregningsgrunnlagPrStatus.builder(bgPerStatus)
             .medBeregnetPrÅr(beregnetPrÅr)
             .medÅrsbeløpFraTilstøtendeYtelse(beregnetPrÅr)

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/FastsettAAPManuelt.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/FastsettAAPManuelt.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.AktivitetStatus;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.BeregningsgrunnlagHjemmel;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.Periode;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.grunnlag.inntekt.Inntektskilde;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.resultat.BeregningsgrunnlagPeriode;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.resultat.BeregningsgrunnlagPrStatus;
@@ -28,8 +29,12 @@ class FastsettAAPManuelt extends LeafSpecification<BeregningsgrunnlagPeriode> {
             .filter(bgps -> bgps.getAktivitetStatus().erAAPellerDP())
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("Ingen aktivitetstatus av type DP eller AAP funnet."));
-        var inntekt = grunnlag.getInntektsgrunnlag().getPeriodeinntekt(Inntektskilde.TILSTØTENDE_YTELSE_DP_AAP, grunnlag.getSkjæringstidspunkt())
-            .orElseThrow(() -> new IllegalStateException("Ingen inntekter fra tilstøtende ytelser funnet i siste måned med inntekt"));
+
+        var aktuellInntektsperiode = Periode.of(grunnlag.getSkjæringstidspunkt().minusDays(8), grunnlag.getSkjæringstidspunkt().plusDays(1));
+        var inntekt = grunnlag.getInntektsgrunnlag()
+            .getSistePeriodeinntektMedTypeIPeriode(Inntektskilde.TILSTØTENDE_YTELSE_DP_AAP, aktuellInntektsperiode)
+            .orElseThrow(() -> new IllegalStateException("Ingen inntekter fra tilstøtende ytelser funnet i siste uke med inntekt"));
+
         var beregnetPrÅr = bgPerStatus.getBeregnetPrÅr();
         Long originalDagsats = inntekt.getInntekt().longValue();
         BeregningsgrunnlagPrStatus.builder(bgPerStatus)

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/FastsettDagpengerManueltEtterBesteberegning.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/FastsettDagpengerManueltEtterBesteberegning.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.BeregningsgrunnlagHjemmel;
+import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.Periode;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.grunnlag.inntekt.Inntektskilde;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.grunnlag.inntekt.Periodeinntekt;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.resultat.BeregningsgrunnlagPeriode;
@@ -39,8 +40,9 @@ class FastsettDagpengerManueltEtterBesteberegning extends LeafSpecification<Bere
         // TODO (PFP-8687): Migrere vekk BeregningsgrunnlagPrStatus#besteberegningPrÅr
         var beregnetPrÅr = dpStatus.getBesteberegningPrÅr() != null ? dpStatus.getBesteberegningPrÅr() : dpStatus.getBeregnetPrÅr();
 
+        var aktuellInntektsperiode = Periode.of(grunnlag.getSkjæringstidspunkt().minusDays(8), grunnlag.getSkjæringstidspunkt().plusDays(1));
         var dagsats = grunnlag.getInntektsgrunnlag()
-            .getPeriodeinntekt(Inntektskilde.TILSTØTENDE_YTELSE_DP_AAP, grunnlag.getSkjæringstidspunkt())
+            .getSistePeriodeinntektMedTypeIPeriode(Inntektskilde.TILSTØTENDE_YTELSE_DP_AAP, aktuellInntektsperiode)
             .map(Periodeinntekt::getInntekt)
             .orElse(BigDecimal.ZERO);
 

--- a/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/FastsettDagpengerManueltEtterBesteberegning.java
+++ b/beregningsregler/src/main/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/FastsettDagpengerManueltEtterBesteberegning.java
@@ -1,13 +1,9 @@
 package no.nav.folketrygdloven.beregningsgrunnlag.ytelse.dagpengerelleraap;
 
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.BeregningsgrunnlagHjemmel;
-import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.Periode;
-import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.grunnlag.inntekt.Inntektskilde;
-import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.grunnlag.inntekt.Periodeinntekt;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.resultat.BeregningsgrunnlagPeriode;
 import no.nav.folketrygdloven.beregningsgrunnlag.regelmodell.resultat.BeregningsgrunnlagPrStatus;
 import no.nav.fpsak.nare.doc.RuleDocumentation;
@@ -40,16 +36,12 @@ class FastsettDagpengerManueltEtterBesteberegning extends LeafSpecification<Bere
         // TODO (PFP-8687): Migrere vekk BeregningsgrunnlagPrStatus#besteberegningPrÅr
         var beregnetPrÅr = dpStatus.getBesteberegningPrÅr() != null ? dpStatus.getBesteberegningPrÅr() : dpStatus.getBeregnetPrÅr();
 
-        var aktuellInntektsperiode = Periode.of(grunnlag.getSkjæringstidspunkt().minusDays(8), grunnlag.getSkjæringstidspunkt().plusDays(1));
-        var dagsats = grunnlag.getInntektsgrunnlag()
-            .getSistePeriodeinntektMedTypeIPeriode(Inntektskilde.TILSTØTENDE_YTELSE_DP_AAP, aktuellInntektsperiode)
-            .map(Periodeinntekt::getInntekt)
-            .orElse(BigDecimal.ZERO);
+        var dagsats = grunnlag.getInntektsgrunnlag().getDagsatsYtelseDpAapVedSkjæringstidspunkt();
 
         BeregningsgrunnlagPrStatus.builder(dpStatus)
             .medBeregnetPrÅr(beregnetPrÅr)
             .medÅrsbeløpFraTilstøtendeYtelse(beregnetPrÅr)
-            .medOrginalDagsatsFraTilstøtendeYtelse(dagsats.longValue())
+            .medOrginalDagsatsFraTilstøtendeYtelse(dagsats != null ? dagsats.longValue() : 0L)
             .build();
         grunnlag.getBeregningsgrunnlag().getAktivitetStatus(dpStatus.getAktivitetStatus()).setHjemmel(hjemmel);
 

--- a/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAPTest.java
+++ b/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAPTest.java
@@ -416,7 +416,7 @@ class RegelFastsettBeregningsgrunnlagDPellerAAPTest {
         var regelResultat = getRegelResultat(evaluation, "input");
         assertThat(regelResultat.beregningsresultat()).isEqualTo(ResultatBeregningType.BEREGNET);
         var bgps = grunnlag.getBeregningsgrunnlagPrStatus(AktivitetStatus.DP);
-        assertThat(bgps.getOrginalDagsatsFraTilstøtendeYtelse()).isEqualTo(0L);
+        assertThat(bgps.getOrginalDagsatsFraTilstøtendeYtelse()).isZero();
     }
 
     private LocalDate førStp(int i) {

--- a/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAPTest.java
+++ b/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAPTest.java
@@ -5,6 +5,7 @@ import static no.nav.folketrygdloven.beregningsgrunnlag.BeregningsgrunnlagScenar
 import static no.nav.folketrygdloven.beregningsgrunnlag.VerifiserBeregningsgrunnlag.verifiserBeregningsgrunnlagBruttoPrPeriodeType;
 import static no.nav.folketrygdloven.regelmodelloversetter.RegelmodellOversetter.getRegelResultat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
@@ -383,6 +384,39 @@ class RegelFastsettBeregningsgrunnlagDPellerAAPTest {
         assertThat(bgps.getBeregnetPrÅr()).isEqualByComparingTo(brutto);
         assertThat(bgps.getÅrsbeløpFraTilstøtendeYtelse()).isEqualByComparingTo(brutto);
         assertThat(bgps.getOrginalDagsatsFraTilstøtendeYtelse()).isEqualTo(2000);
+    }
+
+    @Test
+    void skalFeileForAAPGrunnlagUtenInntektSisteUkeFørSTP() {
+        var inntektsgrunnlag = new Inntektsgrunnlag();
+        inntektsgrunnlag.leggTilPeriodeinntekt(lagInntektsgrunnlagForDag(1611, skjæringstidspunkt.minusDays(8)));
+        var beregningsgrunnlag = settoppGrunnlagMedEnPeriode(skjæringstidspunkt, inntektsgrunnlag, Collections.singletonList(AktivitetStatus.AAP));
+        var grunnlag = beregningsgrunnlag.getBeregningsgrunnlagPerioder().getFirst();
+        BeregningsgrunnlagPrStatus.builder(grunnlag.getBeregningsgrunnlagPrStatus(AktivitetStatus.AAP))
+            .medBeregnetPrÅr(new BigDecimal(324423))
+            .medFastsattAvSaksbehandler(true)
+            .build();
+
+        var regel = new RegelFastsettBeregningsgrunnlagDPellerAAP();
+        assertThatThrownBy(() -> regel.evaluer(grunnlag)).isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Ingen inntekter fra tilstøtende ytelser funnet i siste uke med inntekt");
+    }
+
+    @Test
+    void skalGiIngenDagsatsForDPGrunnlagUtenInntektSisteUkeFørSTP() {
+        var inntektsgrunnlag = new Inntektsgrunnlag();
+        inntektsgrunnlag.leggTilPeriodeinntekt(lagInntektsgrunnlagForDag(600, skjæringstidspunkt.minusDays(8)));
+        var beregningsgrunnlag = settoppGrunnlagMedEnPeriode(skjæringstidspunkt, inntektsgrunnlag, Collections.singletonList(AktivitetStatus.DP));
+        var bgPrStatus = beregningsgrunnlag.getBeregningsgrunnlagPerioder().stream().map(p -> p.getBeregningsgrunnlagPrStatus(AktivitetStatus.DP)).findFirst().get();//NOSONAR
+        BeregningsgrunnlagPrStatus.builder(bgPrStatus).medFastsattAvSaksbehandler(true).medBesteberegningPrÅr(BigDecimal.valueOf(260000)).build();
+        var grunnlag = beregningsgrunnlag.getBeregningsgrunnlagPerioder().getFirst();
+
+        var evaluation = new RegelFastsettBeregningsgrunnlagDPellerAAP().evaluer(grunnlag);
+
+        var regelResultat = getRegelResultat(evaluation, "input");
+        assertThat(regelResultat.beregningsresultat()).isEqualTo(ResultatBeregningType.BEREGNET);
+        var bgps = grunnlag.getBeregningsgrunnlagPrStatus(AktivitetStatus.DP);
+        assertThat(bgps.getOrginalDagsatsFraTilstøtendeYtelse()).isEqualTo(0L);
     }
 
     private LocalDate førStp(int i) {

--- a/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAPTest.java
+++ b/beregningsregler/src/test/java/no/nav/folketrygdloven/beregningsgrunnlag/ytelse/dagpengerelleraap/RegelFastsettBeregningsgrunnlagDPellerAAPTest.java
@@ -398,12 +398,12 @@ class RegelFastsettBeregningsgrunnlagDPellerAAPTest {
             .build();
 
         var regel = new RegelFastsettBeregningsgrunnlagDPellerAAP();
-        assertThatThrownBy(() -> regel.evaluer(grunnlag)).isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("Ingen inntekter fra tilstøtende ytelser funnet i siste uke med inntekt");
+        assertThatThrownBy(() -> regel.evaluer(grunnlag)).isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("Ingen dagsats funnet for AAP ved skjæringstidspunkt");
     }
 
     @Test
-    void skalGiIngenDagsatsForDPGrunnlagUtenInntektSisteUkeFørSTP() {
+    void skalGiIngenDagsatsForDPGrunnlagUtenDagsatsPåStp() {
         var inntektsgrunnlag = new Inntektsgrunnlag();
         inntektsgrunnlag.leggTilPeriodeinntekt(lagInntektsgrunnlagForDag(600, skjæringstidspunkt.minusDays(8)));
         var beregningsgrunnlag = settoppGrunnlagMedEnPeriode(skjæringstidspunkt, inntektsgrunnlag, Collections.singletonList(AktivitetStatus.DP));
@@ -435,6 +435,7 @@ class RegelFastsettBeregningsgrunnlagDPellerAAPTest {
                 .build());
 
         });
+        inntektsgrunnlag.setDagsatsYtelseDpAapVedSkjæringstidspunkt(dagsats);
         return inntektsgrunnlag;
     }
 


### PR DESCRIPTION
* I stedet for å hente inntekter for perioden og finne dagsats derfra bruker vi nå det nye feltet orginalDagsatsFraTilstøtendeYtelse for å avgjøre dagsatsen 
* Legger til tester for å sjekke edge-caser