### PR TITLE
TFP-6539 Håndtere splitt av arbeidsforhold på SVP i mangel av inntekt…

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/FordelBeregningsgrunnlagDtoTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/FordelBeregningsgrunnlagDtoTjeneste.java
@@ -10,9 +10,7 @@ import no.nav.folketrygdloven.kalkulator.guitjenester.fakta.ManuellBehandlingRef
 import no.nav.folketrygdloven.kalkulator.guitjenester.fakta.RefusjonDtoTjeneste;
 import no.nav.folketrygdloven.kalkulator.guitjenester.fakta.RefusjonEllerGraderingArbeidsforholdDtoTjeneste;
 import no.nav.folketrygdloven.kalkulator.input.BeregningsgrunnlagGUIInput;
-import no.nav.folketrygdloven.kalkulator.input.ForeldrepengerGrunnlag;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagPeriodeDto;
-import no.nav.folketrygdloven.kalkulator.modell.gradering.AktivitetGradering;
 import no.nav.folketrygdloven.kalkulator.modell.typer.Beløp;
 import no.nav.folketrygdloven.kalkulus.kodeverk.BeregningsgrunnlagTilstand;
 import no.nav.folketrygdloven.kalkulus.response.v1.beregningsgrunnlag.gui.FordelBeregningsgrunnlagAndelDto;
@@ -67,23 +65,22 @@ public class FordelBeregningsgrunnlagDtoTjeneste {
                                                                              BeregningsgrunnlagGUIInput input,
                                                                              BeregningsgrunnlagPeriodeDto periode,
                                                                              Beløp grunnbeløp) {
-        var aktivitetGradering = input.getYtelsespesifiktGrunnlag() instanceof ForeldrepengerGrunnlag ? ((ForeldrepengerGrunnlag) input.getYtelsespesifiktGrunnlag()).getAktivitetGradering() : AktivitetGradering.INGEN_GRADERING;
         var fordelAndeler = FordelBeregningsgrunnlagAndelDtoTjeneste.lagEndretBgAndelListe(input, periode);
 
         fordelBGPeriode.setHarPeriodeAarsakGraderingEllerRefusjon(
-            ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereInntekt(input.getBeregningsgrunnlagGrunnlag(), aktivitetGradering,
+            ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereInntekt(input.getBeregningsgrunnlagGrunnlag(), input.getYtelsespesifiktGrunnlag(),
                 periode, input.getBeregningsgrunnlag().getBeregningsgrunnlagPerioder(), input.getInntektsmeldinger(), input.getForlengelseperioder(),
                 input.getFagsakYtelseType()));
         fordelBGPeriode.setSkalRedigereInntekt(
-            ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereInntekt(input.getBeregningsgrunnlagGrunnlag(), aktivitetGradering,
+            ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereInntekt(input.getBeregningsgrunnlagGrunnlag(), input.getYtelsespesifiktGrunnlag(),
                 periode, input.getBeregningsgrunnlag().getBeregningsgrunnlagPerioder(), input.getInntektsmeldinger(), input.getForlengelseperioder(),
                 input.getFagsakYtelseType()));
         fordelBGPeriode.setSkalPreutfyllesMedBeregningsgrunnlag(
             ManuellBehandlingRefusjonGraderingDtoTjeneste.skalRedigereGrunnetTidligerePerioder(input.getBeregningsgrunnlagGrunnlag(),
-                aktivitetGradering, periode, input.getBeregningsgrunnlag().getBeregningsgrunnlagPerioder(), input.getInntektsmeldinger(),
+                input.getYtelsespesifiktGrunnlag(), periode, input.getBeregningsgrunnlag().getBeregningsgrunnlagPerioder(), input.getInntektsmeldinger(),
                 input.getForlengelseperioder(), input.getFagsakYtelseType()));
         fordelBGPeriode.setSkalKunneEndreRefusjon(
-            ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereRefusjon(input.getBeregningsgrunnlagGrunnlag(), aktivitetGradering,
+            ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereRefusjon(input.getBeregningsgrunnlagGrunnlag(), input.getYtelsespesifiktGrunnlag(),
                 periode, input.getInntektsmeldinger(), grunnbeløp, input.getForlengelseperioder(),
                 input.getFagsakYtelseType()));
         RefusjonDtoTjeneste.slåSammenRefusjonForAndelerISammeArbeidsforhold(fordelAndeler);

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/ManuellBehandlingRefusjonGraderingDtoTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/ManuellBehandlingRefusjonGraderingDtoTjeneste.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import no.nav.folketrygdloven.kalkulator.input.ForeldrepengerGrunnlag;
+import no.nav.folketrygdloven.kalkulator.input.YtelsespesifiktGrunnlag;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagGrunnlagDto;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagPeriodeDto;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagPrStatusOgAndelDto;
@@ -24,55 +26,56 @@ public class ManuellBehandlingRefusjonGraderingDtoTjeneste {
     }
 
     public static boolean skalSaksbehandlerRedigereInntekt(BeregningsgrunnlagGrunnlagDto grunnlag,
-                                                           AktivitetGradering aktivitetGradering,
+                                                           YtelsespesifiktGrunnlag ytelsespesifiktGrunnlag,
                                                            BeregningsgrunnlagPeriodeDto periode,
                                                            List<BeregningsgrunnlagPeriodeDto> perioder,
                                                            Collection<InntektsmeldingDto> inntektsmeldinger,
                                                            List<Intervall> forlengelseperioder,
                                                            FagsakYtelseType fagsakYtelseType) {
-        var grunnetTidligerePerioder = skalRedigereGrunnetTidligerePerioder(grunnlag, aktivitetGradering, periode, perioder, inntektsmeldinger, forlengelseperioder,
+        var grunnetTidligerePerioder = skalRedigereGrunnetTidligerePerioder(grunnlag, ytelsespesifiktGrunnlag, periode, perioder, inntektsmeldinger, forlengelseperioder,
             fagsakYtelseType);
         if (grunnetTidligerePerioder) {
             return true;
         }
         var periodeTilfelleMap = utledTilfellerForAndelerIPeriode(
                 grunnlag,
-                aktivitetGradering,
+                ytelsespesifiktGrunnlag,
                 periode, inntektsmeldinger, forlengelseperioder, fagsakYtelseType);
         return periode.getBeregningsgrunnlagPrStatusOgAndelList().stream().anyMatch(andelFraSteg -> andelLiggerITilfelleMap(andelFraSteg, periodeTilfelleMap));
     }
 
-    public static boolean skalRedigereGrunnetTidligerePerioder(BeregningsgrunnlagGrunnlagDto grunnlag, AktivitetGradering aktivitetGradering,
+    public static boolean skalRedigereGrunnetTidligerePerioder(BeregningsgrunnlagGrunnlagDto grunnlag, YtelsespesifiktGrunnlag ytelsespesifiktGrunnlag,
                                                                BeregningsgrunnlagPeriodeDto periode, List<BeregningsgrunnlagPeriodeDto> perioder,
                                                                Collection<InntektsmeldingDto> inntektsmeldinger, List<Intervall> forlengelseperioder,
                                                                FagsakYtelseType fagsakYtelseType) {
         return perioder.stream()
                 .filter(p -> p.getBeregningsgrunnlagPeriodeFom().isBefore(periode.getBeregningsgrunnlagPeriodeFom()))
-                .flatMap(p -> utledTilfellerForAndelerIPeriode(grunnlag, aktivitetGradering, p, inntektsmeldinger, forlengelseperioder,
+                .flatMap(p -> utledTilfellerForAndelerIPeriode(grunnlag, ytelsespesifiktGrunnlag, p, inntektsmeldinger, forlengelseperioder,
                     fagsakYtelseType).values().stream())
                 .anyMatch(tilfelle -> tilfelle.equals(FordelingTilfelle.GRADERT_ANDEL_SOM_VILLE_HA_BLITT_AVKORTET_TIL_0)
                         || tilfelle.equals(FordelingTilfelle.FORESLÅTT_BG_PÅ_GRADERT_ANDEL_ER_0));
     }
 
     public static boolean skalSaksbehandlerRedigereRefusjon(BeregningsgrunnlagGrunnlagDto grunnlag,
-                                                            AktivitetGradering aktivitetGradering,
+                                                            YtelsespesifiktGrunnlag ytelsespesifiktGrunnlag,
                                                             BeregningsgrunnlagPeriodeDto periode,
                                                             Collection<InntektsmeldingDto> inntektsmeldinger,
                                                             Beløp grunnbeløp, List<Intervall> forlengelseperioder,
                                                             FagsakYtelseType fagsakYtelseType) {
-        var periodeTilfelleMap = utledTilfellerForAndelerIPeriode(grunnlag, aktivitetGradering,
+        var aktivitetGradering = ytelsespesifiktGrunnlag instanceof ForeldrepengerGrunnlag ? ((ForeldrepengerGrunnlag) ytelsespesifiktGrunnlag).getAktivitetGradering() : AktivitetGradering.INGEN_GRADERING;
+        var periodeTilfelleMap = utledTilfellerForAndelerIPeriode(grunnlag, ytelsespesifiktGrunnlag,
                 periode, inntektsmeldinger, forlengelseperioder, fagsakYtelseType);
         return periode.getBeregningsgrunnlagPrStatusOgAndelList().stream().anyMatch(andelFraSteg -> andelLiggerITilfelleMap(andelFraSteg, periodeTilfelleMap)
                 && RefusjonDtoTjeneste.skalKunneEndreRefusjon(andelFraSteg, periode, aktivitetGradering, grunnbeløp));
     }
 
     private static Map<BeregningsgrunnlagPrStatusOgAndelDto, FordelingTilfelle> utledTilfellerForAndelerIPeriode(BeregningsgrunnlagGrunnlagDto grunnlag,
-                                                                                                                 AktivitetGradering aktivitetGradering,
+                                                                                                                 YtelsespesifiktGrunnlag ytelsespesifiktGrunnlag,
                                                                                                                  BeregningsgrunnlagPeriodeDto periode,
                                                                                                                  Collection<InntektsmeldingDto> inntektsmeldinger,
                                                                                                                  List<Intervall> forlengelseperioder,
                                                                                                                  FagsakYtelseType fagsakYtelseType) {
-        var fordelingInput = new FordelBeregningsgrunnlagTilfelleInput(grunnlag.getBeregningsgrunnlagHvisFinnes().orElse(null), aktivitetGradering,
+        var fordelingInput = new FordelBeregningsgrunnlagTilfelleInput(grunnlag.getBeregningsgrunnlagHvisFinnes().orElse(null), ytelsespesifiktGrunnlag,
             inntektsmeldinger, forlengelseperioder, fagsakYtelseType);
         return FordelBeregningsgrunnlagTilfelleTjeneste.vurderManuellBehandlingForPeriode(periode, fordelingInput);
     }

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/svp/AktivitetDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/svp/AktivitetDto.java
@@ -12,11 +12,19 @@ public final class AktivitetDto {
     private final Arbeidsgiver arbeidsgiver;
     private final InternArbeidsforholdRefDto internArbeidsforholdRef;
     private final UttakArbeidType uttakArbeidType;
+    private boolean arbeidsforholdErSplittet = false;
 
     public AktivitetDto(Arbeidsgiver arbeidsgiver, InternArbeidsforholdRefDto internArbeidsforholdRef, UttakArbeidType uttakArbeidType) {
         this.arbeidsgiver = arbeidsgiver;
         this.internArbeidsforholdRef = Objects.requireNonNull(internArbeidsforholdRef, "internArbeidsforholdRef");
         this.uttakArbeidType = uttakArbeidType;
+    }
+
+    public AktivitetDto(Arbeidsgiver arbeidsgiver, InternArbeidsforholdRefDto internArbeidsforholdRef, UttakArbeidType uttakArbeidType, boolean arbeidsforholdErSplittet) {
+        this.arbeidsgiver = arbeidsgiver;
+        this.internArbeidsforholdRef = Objects.requireNonNull(internArbeidsforholdRef, "internArbeidsforholdRef");
+        this.uttakArbeidType = uttakArbeidType;
+        this.arbeidsforholdErSplittet = arbeidsforholdErSplittet;
     }
 
     public Optional<Arbeidsgiver> getArbeidsgiver() {
@@ -31,6 +39,10 @@ public final class AktivitetDto {
         return uttakArbeidType;
     }
 
+    public boolean getArbeidsforholdErSplittet() {
+        return arbeidsforholdErSplittet;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -38,12 +50,13 @@ public final class AktivitetDto {
 	    var that = (AktivitetDto) o;
         return Objects.equals(arbeidsgiver, that.arbeidsgiver) &&
             Objects.equals(internArbeidsforholdRef, that.internArbeidsforholdRef) &&
-            Objects.equals(uttakArbeidType, that.uttakArbeidType);
+            Objects.equals(uttakArbeidType, that.uttakArbeidType) &&
+            Objects.equals(arbeidsforholdErSplittet, that.arbeidsforholdErSplittet);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(arbeidsgiver, internArbeidsforholdRef, uttakArbeidType);
+        return Objects.hash(arbeidsgiver, internArbeidsforholdRef, uttakArbeidType, arbeidsforholdErSplittet);
     }
 
 }

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederFordelBeregning.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/AvklaringsbehovUtlederFordelBeregning.java
@@ -5,11 +5,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import no.nav.folketrygdloven.kalkulator.input.ForeldrepengerGrunnlag;
 import no.nav.folketrygdloven.kalkulator.input.YtelsespesifiktGrunnlag;
 import no.nav.folketrygdloven.kalkulator.modell.behandling.KoblingReferanse;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagGrunnlagDto;
-import no.nav.folketrygdloven.kalkulator.modell.gradering.AktivitetGradering;
 import no.nav.folketrygdloven.kalkulator.modell.iay.InntektArbeidYtelseGrunnlagDto;
 import no.nav.folketrygdloven.kalkulator.modell.iay.InntektsmeldingAggregatDto;
 import no.nav.folketrygdloven.kalkulator.modell.iay.InntektsmeldingDto;
@@ -51,12 +49,8 @@ public class AvklaringsbehovUtlederFordelBeregning {
                                                                         List<Intervall> forlengelseperioder) {
 	    var beregningsgrunnlag = beregningsgrunnlagGrunnlag.getBeregningsgrunnlagHvisFinnes()
                 .orElseThrow(() -> new IllegalStateException("Utviklerfeil: Mangler beregningsgrunnlagGrunnlag"));
-	    var fordelingInput = new FordelBeregningsgrunnlagTilfelleInput(beregningsgrunnlag, finnGraderinger(ytelsespesifiktGrunnlag),
+	    var fordelingInput = new FordelBeregningsgrunnlagTilfelleInput(beregningsgrunnlag, ytelsespesifiktGrunnlag,
             inntektsmeldinger, forlengelseperioder, ref.getFagsakYtelseType());
         return FordelBeregningsgrunnlagTilfelleTjeneste.finnPerioderMedBehovForManuellVurdering(fordelingInput);
-    }
-
-    private static AktivitetGradering finnGraderinger(YtelsespesifiktGrunnlag ytelsespesifiktGrunnlag) {
-        return ytelsespesifiktGrunnlag instanceof ForeldrepengerGrunnlag ? ((ForeldrepengerGrunnlag) ytelsespesifiktGrunnlag).getAktivitetGradering() : AktivitetGradering.INGEN_GRADERING;
     }
 }

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/FordelBeregningsgrunnlagTilfelleInput.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/FordelBeregningsgrunnlagTilfelleInput.java
@@ -6,9 +6,8 @@ import java.util.List;
 import java.util.Objects;
 
 import no.nav.folketrygdloven.kalkulator.input.BeregningsgrunnlagGUIInput;
-import no.nav.folketrygdloven.kalkulator.input.ForeldrepengerGrunnlag;
+import no.nav.folketrygdloven.kalkulator.input.YtelsespesifiktGrunnlag;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagDto;
-import no.nav.folketrygdloven.kalkulator.modell.gradering.AktivitetGradering;
 import no.nav.folketrygdloven.kalkulator.modell.iay.InntektsmeldingDto;
 import no.nav.folketrygdloven.kalkulator.tid.Intervall;
 import no.nav.folketrygdloven.kalkulus.kodeverk.FagsakYtelseType;
@@ -20,17 +19,17 @@ public class FordelBeregningsgrunnlagTilfelleInput {
 
     private final List<Intervall> forlengelseperioder;
     private BeregningsgrunnlagDto beregningsgrunnlag;
-    private AktivitetGradering aktivitetGradering;
+    private YtelsespesifiktGrunnlag ytelsespesifiktGrunnlag;
     private Collection<InntektsmeldingDto> inntektsmeldinger;
     private final FagsakYtelseType fagsakYtelseType;
 
 
     public FordelBeregningsgrunnlagTilfelleInput(BeregningsgrunnlagDto beregningsgrunnlag,
-                                                 AktivitetGradering aktivitetGradering,
+                                                 YtelsespesifiktGrunnlag ytelsespesifiktGrunnlag,
                                                  Collection<InntektsmeldingDto> inntektsmeldinger, List<Intervall> forlengelseperioder,
                                                  FagsakYtelseType fagsakYtelseType) {
         this.beregningsgrunnlag = beregningsgrunnlag;
-        this.aktivitetGradering = aktivitetGradering;
+        this.ytelsespesifiktGrunnlag = ytelsespesifiktGrunnlag;
         this.inntektsmeldinger = inntektsmeldinger;
         this.forlengelseperioder = forlengelseperioder;
         this.fagsakYtelseType = fagsakYtelseType;
@@ -41,8 +40,8 @@ public class FordelBeregningsgrunnlagTilfelleInput {
         return beregningsgrunnlag;
     }
 
-    public AktivitetGradering getAktivitetGradering() {
-        return aktivitetGradering;
+    public YtelsespesifiktGrunnlag ytelsespesifiktGrunnlag() {
+        return ytelsespesifiktGrunnlag;
     }
 
     public Collection<InntektsmeldingDto> getInntektsmeldinger() {
@@ -61,17 +60,15 @@ public class FordelBeregningsgrunnlagTilfelleInput {
     public String toString() {
         return "FordelBeregningsgrunnlagTilfelleInput{" +
                 "beregningsgrunnlag=" + beregningsgrunnlag +
-                ", aktivitetGradering=" + aktivitetGradering +
+                ", ytelsespesifiktGrunnlag=" + ytelsespesifiktGrunnlag +
                 ", inntektsmeldinger=" + inntektsmeldinger +
                 ", fagsakYtelseType=" + fagsakYtelseType +
             '}';
     }
 
     public static FordelBeregningsgrunnlagTilfelleInput fraBeregningsgrunnlagRestInput(BeregningsgrunnlagGUIInput input) {
-        var aktivitetGradering = input.getYtelsespesifiktGrunnlag() instanceof ForeldrepengerGrunnlag ?
-                ((ForeldrepengerGrunnlag) input.getYtelsespesifiktGrunnlag()).getAktivitetGradering() : AktivitetGradering.INGEN_GRADERING;
         var inntektsmeldinger = input.getInntektsmeldinger();
-        return new FordelBeregningsgrunnlagTilfelleInput(input.getBeregningsgrunnlag(), aktivitetGradering, inntektsmeldinger,
+        return new FordelBeregningsgrunnlagTilfelleInput(input.getBeregningsgrunnlag(), input.getYtelsespesifiktGrunnlag(), inntektsmeldinger,
             input.getForlengelseperioder(), input.getFagsakYtelseType());
     }
 

--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/FordelBeregningsgrunnlagTilfelleTjeneste.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/steg/fordeling/avklaringsbehov/FordelBeregningsgrunnlagTilfelleTjeneste.java
@@ -8,10 +8,14 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import no.nav.folketrygdloven.kalkulator.avklaringsbehov.PerioderTilVurderingTjeneste;
+import no.nav.folketrygdloven.kalkulator.input.ForeldrepengerGrunnlag;
+import no.nav.folketrygdloven.kalkulator.input.SvangerskapspengerGrunnlag;
+import no.nav.folketrygdloven.kalkulator.input.YtelsespesifiktGrunnlag;
 import no.nav.folketrygdloven.kalkulator.konfig.KonfigTjeneste;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BGAndelArbeidsforholdDto;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagPeriodeDto;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagPrStatusOgAndelDto;
+import no.nav.folketrygdloven.kalkulator.modell.gradering.AktivitetGradering;
 import no.nav.folketrygdloven.kalkulator.modell.typer.Beløp;
 import no.nav.folketrygdloven.kalkulator.tid.Intervall;
 import no.nav.folketrygdloven.kalkulus.kodeverk.FagsakYtelseType;
@@ -49,13 +53,19 @@ public final class FordelBeregningsgrunnlagTilfelleTjeneste {
                                                                      FordelBeregningsgrunnlagTilfelleInput input,
                                                                      BeregningsgrunnlagPrStatusOgAndelDto andel) {
         boolean erNyAktivitet = FordelTilkommetArbeidsforholdTjeneste.erAktivitetLagtTilIPeriodisering(andel);
-        boolean skalManueltFordeles = !erAutomatiskFordelt(andel) || FagsakYtelseType.SVANGERSKAPSPENGER.equals(input.getFagsakYtelseType());
-        if (erNyAktivitet && skalManueltFordeles) {
+        var erSvp = FagsakYtelseType.SVANGERSKAPSPENGER.equals(input.getFagsakYtelseType());
+        boolean skalManueltFordeles = !erAutomatiskFordelt(andel) || erSvp;
+
+        var arbeidsforholdErSplittetSvp = erManueltSpittetArbeidsforhold(input.ytelsespesifiktGrunnlag()) && erSvp;
+
+        if (arbeidsforholdErSplittetSvp || (erNyAktivitet && skalManueltFordeles)) {
             return Optional.of(FordelingTilfelle.NY_AKTIVITET);
         }
 
         boolean andelHarRefusjonIPerioden = harInnvilgetRefusjon(andel);
-        var harGraderingIBGPeriode = FordelingGraderingTjeneste.harGraderingForAndelIPeriode(andel, input.getAktivitetGradering(), periode.getPeriode());
+        var aktivitetGradering = input.ytelsespesifiktGrunnlag() instanceof ForeldrepengerGrunnlag ?
+            ((ForeldrepengerGrunnlag) input.ytelsespesifiktGrunnlag()).getAktivitetGradering() : AktivitetGradering.INGEN_GRADERING;
+        var harGraderingIBGPeriode = FordelingGraderingTjeneste.harGraderingForAndelIPeriode(andel, aktivitetGradering, periode.getPeriode());
         if (!harGraderingIBGPeriode && !andelHarRefusjonIPerioden) {
             return Optional.empty();
         }
@@ -75,6 +85,15 @@ public final class FordelBeregningsgrunnlagTilfelleTjeneste {
             }
         }
         return Optional.empty();
+    }
+
+    private static boolean erManueltSpittetArbeidsforhold(YtelsespesifiktGrunnlag ytelsespesifiktGrunnlag) {
+        if (ytelsespesifiktGrunnlag instanceof SvangerskapspengerGrunnlag svpGrunnlag) {
+            return svpGrunnlag.getUtbetalingsgradPrAktivitet()
+                .stream()
+                .anyMatch(t -> t.getUtbetalingsgradArbeidsforhold().getArbeidsforholdErSplittet());
+        }
+        return false;
     }
 
     private static Boolean harInnvilgetRefusjon(BeregningsgrunnlagPrStatusOgAndelDto andel) {

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/ManuellBehandlingRefusjonGraderingDtoTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/guitjenester/fakta/ManuellBehandlingRefusjonGraderingDtoTjenesteTest.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import no.nav.folketrygdloven.kalkulator.input.ForeldrepengerGrunnlag;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BGAndelArbeidsforholdDto;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningAktivitetAggregatDto;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningAktivitetDto;
@@ -29,6 +30,7 @@ import no.nav.folketrygdloven.kalkulator.modell.typer.Beløp;
 import no.nav.folketrygdloven.kalkulator.tid.Intervall;
 import no.nav.folketrygdloven.kalkulus.kodeverk.AktivitetStatus;
 import no.nav.folketrygdloven.kalkulus.kodeverk.BeregningsgrunnlagTilstand;
+import no.nav.folketrygdloven.kalkulus.kodeverk.Dekningsgrad;
 import no.nav.folketrygdloven.kalkulus.kodeverk.FagsakYtelseType;
 import no.nav.folketrygdloven.kalkulus.kodeverk.Inntektskategori;
 import no.nav.folketrygdloven.kalkulus.kodeverk.OpptjeningAktivitetType;
@@ -71,6 +73,9 @@ class ManuellBehandlingRefusjonGraderingDtoTjenesteTest {
     void skalKunneEndreInntektEtterRedusertRefusjonTilUnder6G() {
         // Arrange
         var graderinger = lagGradering();
+        var aktivitetGradering = new AktivitetGradering(graderinger);
+        var foreldrepengeGrunnlag = new ForeldrepengerGrunnlag(Dekningsgrad.DEKNINGSGRAD_100, false, aktivitetGradering);
+
         var bgFørFordeling = lagBeregningsgrunnlagFørFordeling();
 
         var inntektsmeldinger = lagInntektsmeldingOver6GRefusjon();
@@ -81,7 +86,7 @@ class ManuellBehandlingRefusjonGraderingDtoTjenesteTest {
 
         // Act
         var kreverManuellBehandling = ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereInntekt(grunnlag,
-                new AktivitetGradering(graderinger), bgFørFordeling.getBeregningsgrunnlagPerioder().get(0),
+                foreldrepengeGrunnlag, bgFørFordeling.getBeregningsgrunnlagPerioder().get(0),
             bgFørFordeling.getBeregningsgrunnlagPerioder(), inntektsmeldinger, Collections.emptyList(), FagsakYtelseType.FORELDREPENGER);
 
         // Assert
@@ -94,6 +99,9 @@ class ManuellBehandlingRefusjonGraderingDtoTjenesteTest {
         // Arrange
         var graderingTom = SKJÆRINGSTIDSPUNKT_OPPTJENING.plusMonths(1);
         var graderingNæring = lagGraderingForNæringFraSTP(graderingTom);
+        var aktivitetGradering = new AktivitetGradering(graderingNæring);
+        var foreldrepengeGrunnlag = new ForeldrepengerGrunnlag(Dekningsgrad.DEKNINGSGRAD_100, false, aktivitetGradering);
+
         var bg = BeregningsgrunnlagDto.builder()
                 .medSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT_OPPTJENING)
                 .medGrunnbeløp(Beløp.fra(GRUNNBELØP))
@@ -112,7 +120,7 @@ class ManuellBehandlingRefusjonGraderingDtoTjenesteTest {
         // Act
         var kreverManuellBehandling1 = ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereInntekt(
                 grunnlag,
-                new AktivitetGradering(graderingNæring),
+                foreldrepengeGrunnlag,
                 periode,
                 bg.getBeregningsgrunnlagPerioder(),
                 List.of(), Collections.emptyList(),
@@ -120,7 +128,7 @@ class ManuellBehandlingRefusjonGraderingDtoTjenesteTest {
 
         var kreverManuellBehandling2 = ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereInntekt(
                 grunnlag,
-                new AktivitetGradering(graderingNæring),
+                foreldrepengeGrunnlag,
                 periode2,
                 bg.getBeregningsgrunnlagPerioder(),
                 List.of(), Collections.emptyList(),
@@ -136,6 +144,8 @@ class ManuellBehandlingRefusjonGraderingDtoTjenesteTest {
     void skalKunneEndreRefusjonEtterRedusertRefusjonTilUnder6G() {
         // Arrange
         var graderinger = lagGradering();
+        var aktivitetGradering = new AktivitetGradering(graderinger);
+        var foreldrepengeGrunnlag = new ForeldrepengerGrunnlag(Dekningsgrad.DEKNINGSGRAD_100, false, aktivitetGradering);
         var bgFørFordeling = lagBeregningsgrunnlagFørFordeling();
         var inntektsmeldinger = lagInntektsmeldingOver6GRefusjon();
 
@@ -146,7 +156,7 @@ class ManuellBehandlingRefusjonGraderingDtoTjenesteTest {
         // Act
         var kreverManuellBehandlingAvRefusjon = ManuellBehandlingRefusjonGraderingDtoTjeneste.skalSaksbehandlerRedigereRefusjon(
                 grunnlag,
-            new AktivitetGradering(graderinger),
+            foreldrepengeGrunnlag,
             bgFørFordeling.getBeregningsgrunnlagPerioder().get(0), inntektsmeldinger, Beløp.fra(GRUNNBELØP), Collections.emptyList(),
             FagsakYtelseType.FORELDREPENGER);
 

--- a/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/kontrollerfakta/RefusjonOgGraderingTjenesteTest.java
+++ b/kalkulator/src/test/java/no/nav/folketrygdloven/kalkulator/steg/kontrollerfakta/RefusjonOgGraderingTjenesteTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import no.nav.folketrygdloven.kalkulator.input.ForeldrepengerGrunnlag;
 import no.nav.folketrygdloven.kalkulator.konfig.KonfigTjeneste;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BGAndelArbeidsforholdDto;
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagAktivitetStatusDto;
@@ -28,6 +29,7 @@ import no.nav.folketrygdloven.kalkulator.steg.fordeling.avklaringsbehov.FordelBe
 import no.nav.folketrygdloven.kalkulator.steg.fordeling.avklaringsbehov.FordelingTilfelle;
 import no.nav.folketrygdloven.kalkulator.testutilities.BeregningInntektsmeldingTestUtil;
 import no.nav.folketrygdloven.kalkulus.kodeverk.AktivitetStatus;
+import no.nav.folketrygdloven.kalkulus.kodeverk.Dekningsgrad;
 import no.nav.folketrygdloven.kalkulus.kodeverk.AndelKilde;
 import no.nav.folketrygdloven.kalkulus.kodeverk.FagsakYtelseType;
 import no.nav.folketrygdloven.kalkulus.kodeverk.PeriodeÅrsak;
@@ -348,7 +350,7 @@ class RefusjonOgGraderingTjenesteTest {
             .build());
 
         // Act
-        var fordelingInput = new FordelBeregningsgrunnlagTilfelleInput(bg, aktivitetGradering, List.of(im1), Collections.emptyList(),
+        var fordelingInput = new FordelBeregningsgrunnlagTilfelleInput(bg, new ForeldrepengerGrunnlag(Dekningsgrad.DEKNINGSGRAD_100, false, aktivitetGradering), List.of(im1), Collections.emptyList(),
             FagsakYtelseType.FORELDREPENGER);
         var andelerMedTilfeller = FordelBeregningsgrunnlagTilfelleTjeneste.vurderManuellBehandlingForPeriode(periode1, fordelingInput);
 
@@ -379,7 +381,7 @@ class RefusjonOgGraderingTjenesteTest {
 
 
     private Map<BeregningsgrunnlagPrStatusOgAndelDto, FordelingTilfelle> vurderManuellBehandling(BeregningsgrunnlagDto bg, AktivitetGradering aktivitetGradering, Collection<InntektsmeldingDto> inntektsmeldinger) {
-        var fordelingInput = new FordelBeregningsgrunnlagTilfelleInput(bg, aktivitetGradering, inntektsmeldinger, Collections.emptyList(), FagsakYtelseType.FORELDREPENGER);
+        var fordelingInput = new FordelBeregningsgrunnlagTilfelleInput(bg, new ForeldrepengerGrunnlag(Dekningsgrad.DEKNINGSGRAD_100, false, aktivitetGradering), inntektsmeldinger, Collections.emptyList(), FagsakYtelseType.FORELDREPENGER);
         return fordelingInput.getBeregningsgrunnlag().getBeregningsgrunnlagPerioder().stream()
                 .map(p -> FordelBeregningsgrunnlagTilfelleTjeneste.vurderManuellBehandlingForPeriode(p, fordelingInput))
                 .filter(r -> !r.isEmpty())


### PR DESCRIPTION
…smelding med arb.id og flere arbeidsforhold under samme underenhet:

* Nytt flagg på AktivetDto - arbeidsforholdErSplittet
* endrer input til FordelBeregningsgrunnlagTilfelleInput til ytelsespesifiktGrunnlag for å få tilgang på om arbeidsforholdet er splittet i fordeling
* oppretter fordelingTilfelle dersom andelen er splittet og svp i FordelBeregningsgrunnlagTilfelleTjeneste