### PR TITLE
FIX: Sjekker ikkje periodeårsak ved diff-sjekk for kopi

### DIFF
--- a/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/beregningsgrunnlag/BeregningsgrunnlagPeriodeDto.java
+++ b/kalkulator/src/main/java/no/nav/folketrygdloven/kalkulator/modell/beregningsgrunnlag/BeregningsgrunnlagPeriodeDto.java
@@ -36,7 +36,7 @@ public class BeregningsgrunnlagPeriodeDto implements IndexKey {
     private Beløp avkortetPrÅr;
     private Beløp redusertPrÅr;
     private Long dagsats;
-    @SjekkVedKopiering
+    // Ikkje legg til @SjekkVedKopiering her. Det ødelegger difflogikk ved forlengelse
     private List<BeregningsgrunnlagPeriodeÅrsakDto> beregningsgrunnlagPeriodeÅrsaker = new ArrayList<>();
     private BigDecimal inntektgraderingsprosentBrutto;
     private BigDecimal totalUtbetalingsgradFraUttak;


### PR DESCRIPTION
Endringen påvirker logikken som avgjør om det har vært endringer i beregningsgrunnlaget. 

Endringssjekken kjøres i ft-kalkulus for å avgjøre om beregningsgrunnlaget som returneres ved kjøring av steget er likt det som ble returnert fra steget i en tidligere kjøring (i tilfelle revurdering). Dersom det ikke detekteres endringer og steget returnerer et avklaringsbehov vil vi kunne sette steg-ut-tilstanden til aktiv siden man da antar at saksbehandler vil løse avklaringsbehovet på samme måte som forrige gang.

Denne endringen påvirker da om man anser endringer periodeårsak som en relevant endring for å **hindre** denne kopieringen. Vurderingen er at en periodesplitt i seg selv ikke er en grunn til å ikke kopiere forrige vurdering, men dette bør heller baseres på andre felter i beregningsgrunnlaget. 

TLDR: Fjerning av annotasjonen gjør at vi i flere tilfeller vil kunne hoppe til steg-ut-tilstanden og preutfylle opplysninger fra forrige vurdering i revurderinger